### PR TITLE
S3CSI-1: disable aws based ci workflow triggers and migrate unit tests to Scality CI & Codecov

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,10 @@
 name: Release
 
-on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+# on:
+#   push:
+#     # Sequence of patterns matched against refs/tags
+#     tags:
+#       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,12 +1,12 @@
 name: Unit tests
 
-on:
-  push:
-    branches: [ "main", "feature/*" ]
-  pull_request:
-    branches: [ "main", "feature/*" ]
-  merge_group:
-    types: [ "checks_requested" ]
+# on:
+#   push:
+#     branches: [ "main", "feature/*" ]
+#   pull_request:
+#     branches: [ "main", "feature/*" ]
+#   merge_group:
+#     types: [ "checks_requested" ]
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,21 +29,11 @@ jobs:
       # Run tests as root as we require it for systemd tests
       run: sudo make test
 
-    # - name: Check test coverage
-    #   run: make cover
+    - name: Check test coverage
+      run: make cover
 
-    # - name: Upload report
-    #   uses: actions/upload-artifact@v4
-    #   id: uploaded-report
-    #   with:
-    #     name: cover
-    #     path: cover.html
-
-    # - name: Comment test coverage
-    #   if: ${{ github.event_name == 'pull_request' }}
-    #   env:
-    #     TOTAL_COVERAGE: ${{ steps.go-test-coverage.outputs.total-coverage }}
-    #     ARTIFACT_URL: ${{ steps.uploaded-report.outputs.artifact-url }}
-    #   run: |
-    #     echo "### Total test coverage: ${{ env.TOTAL_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
-    #     echo "Download report: ${{ env.ARTIFACT_URL }}" >> $GITHUB_STEP_SUMMARY
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: scality/mountpoint-s3-csi-driver

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,12 +1,9 @@
 name: Unit tests
 
-# on:
-#   push:
-#     branches: [ "main", "feature/*" ]
-#   pull_request:
-#     branches: [ "main", "feature/*" ]
-#   merge_group:
-#     types: [ "checks_requested" ]
+on:
+  push:
+    branches:
+      - '**'
 
 jobs:
   build:
@@ -32,21 +29,21 @@ jobs:
       # Run tests as root as we require it for systemd tests
       run: sudo make test
 
-    - name: Check test coverage
-      run: make cover
+    # - name: Check test coverage
+    #   run: make cover
 
-    - name: Upload report
-      uses: actions/upload-artifact@v4
-      id: uploaded-report
-      with:
-        name: cover
-        path: cover.html
+    # - name: Upload report
+    #   uses: actions/upload-artifact@v4
+    #   id: uploaded-report
+    #   with:
+    #     name: cover
+    #     path: cover.html
 
-    - name: Comment test coverage
-      if: ${{ github.event_name == 'pull_request' }}
-      env:
-        TOTAL_COVERAGE: ${{ steps.go-test-coverage.outputs.total-coverage }}
-        ARTIFACT_URL: ${{ steps.uploaded-report.outputs.artifact-url }}
-      run: |
-        echo "### Total test coverage: ${{ env.TOTAL_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
-        echo "Download report: ${{ env.ARTIFACT_URL }}" >> $GITHUB_STEP_SUMMARY
+    # - name: Comment test coverage
+    #   if: ${{ github.event_name == 'pull_request' }}
+    #   env:
+    #     TOTAL_COVERAGE: ${{ steps.go-test-coverage.outputs.total-coverage }}
+    #     ARTIFACT_URL: ${{ steps.uploaded-report.outputs.artifact-url }}
+    #   run: |
+    #     echo "### Total test coverage: ${{ env.TOTAL_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
+    #     echo "Download report: ${{ env.ARTIFACT_URL }}" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ go.work.sum
 .github/artifacts/benchmark-data.json
 .github/artifacts/data.json
 cover.out
-cover.html
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test:
 .PHONY: cover
 cover:
 	${GOBIN}/go-test-coverage --config=./.testcoverage.yml
-	go tool cover -html=cover.out -o=cover.html
+	go tool cover -html=cover.out -o=coverage.txt
 
 .PHONY: fmt
 fmt:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  notify:
+    wait_for_ci: true
+    after_n_builds: 1
+
+comment:
+  layout: newheader, reach, files, components, diff, flags # show component info in the PR comment
+  hide_comment_details: true  # hide the comment details (e.g. coverage targets) in the PR comment
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 30%
+        removed_code_behavior: adjust_base
+    patch:
+      default:
+        target: 90%
+        threshold: 10%
+
+github_checks:
+  annotations: true
+
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses: []


### PR DESCRIPTION
Comment out workflow triggers to prevent automatic CI runs:
- Comment out push, pull_request, and merge_group triggers
- This will prevent any automatic workflow executions
- Workflows will be moved to Scality Github infrastructure and re-enabled once complete in further PRs, here we have enabled unit tests in later commits.


* [`.github/workflows/unit-tests.yaml`](diffhunk://#diff-6e608e02c595d53ab6b70822a2bf19abcfc6ddcc976c2f536ad5bfca20f0443fL5-R6): Updated the `on` trigger for push events to include all branches and changed the job to upload coverage reports to Codecov instead of using the `upload-artifact`

Changes to test coverage reporting:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L150-R150): Changed the output file name for the coverage report from `cover.html` to `coverage.txt`.
* [`codecov.yml`](diffhunk://#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40dbR1-R23): Added a new configuration file for Codecov to manage comments, coverage status, GitHub checks, and flag management.