### PR TITLE
S3CSI-5: Support credentials(AK/SK/Token) at volume (PV) level

### DIFF
--- a/examples/kubernetes/static_provisioning/aws_max_attempts.yaml
+++ b/examples/kubernetes/static_provisioning/aws_max_attempts.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/caching.yaml
+++ b/examples/kubernetes/static_provisioning/caching.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/kms_sse.yaml
+++ b/examples/kubernetes/static_provisioning/kms_sse.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/multiple_buckets_one_pod.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_buckets_one_pod.yaml
@@ -75,7 +75,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; echo 'Hello from the container!' >> /data2/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: s3-app
-        image: centos
+        image: ubuntu
         command: ["/bin/sh"]
         args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
         volumeMounts:

--- a/examples/kubernetes/static_provisioning/non_root.yaml
+++ b/examples/kubernetes/static_provisioning/non_root.yaml
@@ -44,7 +44,7 @@ spec:
     runAsGroup: 2000
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
+++ b/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/static_provisioning.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/static_provisioning_with_pv_credentials.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning_with_pv_credentials.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3-pv
+spec:
+  capacity:
+    storage: 1200Gi # ignored, required
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
+  mountOptions:
+    - allow-delete
+    - force-path-style
+    - region us-east-1
+    - endpoint-url https://play.min.io
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume # Must be unique
+    volumeAttributes:
+      bucketName: builds
+      accessKeyId: accessKey1
+      secretAccessKey: verySecretKey1
+      authenticationSource: attr # required to use credentials from volumeAttributes
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-pvc
+spec:
+  accessModes:
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  resources:
+    requests:
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-app
+  labels:
+    app: s3-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-app
+  template:
+    metadata:
+      labels:
+        app: s3-app
+    spec:
+      containers:
+      - name: s3-app
+        image: ubuntu
+        command: ["/bin/sh"]
+        args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
+        volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+        ports:
+        - containerPort: 80
+      volumes:
+      - name: persistent-storage
+        persistentVolumeClaim:
+          claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/static_provisioning_with_shared_cache.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning_with_shared_cache.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; echo 'Shared cache test' >> /data/shared_cache_test.txt; cat /data/shared_cache_test.txt; tail -f /dev/null"]
       volumeMounts:

--- a/pkg/driver/node/credentialprovider/provider.go
+++ b/pkg/driver/node/credentialprovider/provider.go
@@ -34,6 +34,7 @@ const (
 	AuthenticationSourceUnspecified AuthenticationSource = ""
 	AuthenticationSourceDriver      AuthenticationSource = "driver"
 	AuthenticationSourcePod         AuthenticationSource = "pod"
+	AuthenticationSourceAttr        AuthenticationSource = "attr"
 )
 
 // A Provider provides methods for accessing AWS credentials.
@@ -66,6 +67,10 @@ type ProvideContext struct {
 	PodNamespace         string
 	ServiceAccountTokens string
 	ServiceAccountName   string
+	// Authentication values in volume attributes
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
 	// StsRegion is the `stsRegion` parameter passed via volume attribute.
 	StsRegion string
 	// BucketRegion is the `--region` parameter passed via mount options.
@@ -99,6 +104,9 @@ func (c *Provider) Provide(ctx context.Context, provideCtx ProvideContext) (envp
 	case AuthenticationSourcePod:
 		env, err := c.provideFromPod(ctx, provideCtx)
 		return env, AuthenticationSourcePod, err
+	case AuthenticationSourceAttr:
+		env, err := c.provideFromAttr(provideCtx)
+		return env, AuthenticationSourceAttr, err
 	case AuthenticationSourceUnspecified, AuthenticationSourceDriver:
 		env, err := c.provideFromDriver(provideCtx)
 		return env, AuthenticationSourceDriver, err

--- a/pkg/driver/node/credentialprovider/provider_attr.go
+++ b/pkg/driver/node/credentialprovider/provider_attr.go
@@ -1,0 +1,22 @@
+package credentialprovider
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
+)
+
+// provideFromAttr provides driver-level AWS credentials.
+func (c *Provider) provideFromAttr(provideCtx ProvideContext) (envprovider.Environment, error) {
+	klog.V(4).Infof("credentialprovider: Using volume attributes identity, provide context: %+v", provideCtx)
+	if (provideCtx.AccessKeyID != "" && provideCtx.SecretAccessKey != "") || provideCtx.SessionToken != "" {
+		return envprovider.Environment{
+			envprovider.EnvAccessKeyID:     provideCtx.AccessKeyID,
+			envprovider.EnvSecretAccessKey: provideCtx.SecretAccessKey,
+			envprovider.EnvSessionToken:    provideCtx.SessionToken,
+		}, nil
+	}
+	return nil, status.Error(codes.InvalidArgument, "Missing credentials. Please make sure volume attributes identity")
+}

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -268,6 +268,9 @@ func credentialProvideContextFromPublishRequest(req *csi.NodePublishVolumeReques
 		ServiceAccountName:   volumeCtx[volumecontext.CSIServiceAccountName],
 		StsRegion:            volumeCtx[volumecontext.STSRegion],
 		BucketRegion:         bucketRegion,
+		AccessKeyID:          volumeCtx[volumecontext.AccessKeyID],
+		SecretAccessKey:      volumeCtx[volumecontext.SecretAccessKey],
+		SessionToken:         volumeCtx[volumecontext.SessionToken],
 	}
 }
 

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -5,6 +5,9 @@ const (
 	BucketName           = "bucketName"
 	AuthenticationSource = "authenticationSource"
 	STSRegion            = "stsRegion"
+	AccessKeyID          = "accessKeyId"
+	SecretAccessKey      = "secretAccessKey"
+	SessionToken         = "sessionToken"
 
 	MountpointPodServiceAccountName = "mountpointPodServiceAccountName"
 


### PR DESCRIPTION
Add support for volume level creds
Tests will be updated in this ticket once the CI is working with all E2E tests (ticket reference: [S3CSI-11](https://scality.atlassian.net/browse/S3CSI-11))

[S3CSI-11]: https://scality.atlassian.net/browse/S3CSI-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

The alternate long-term better would be to add this functionality in [mountpoint-s3](https://github.com/scality/mountpoint-s3) directly but for now we are keeping it simple