### PR TITLE
S3CSI-3: Add ability to specify S3 endpoint at CSI driver level

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
@@ -115,6 +115,10 @@ spec:
             - name: MOUNTPOINT_NAMESPACE
               value: {{ .Values.mountpointPod.namespace }}
             {{- end -}}
+            {{- if .Values.node.s3EndpointUrl }}
+            - name: AWS_ENDPOINT_URL
+              value: {{ .Values.node.s3EndpointUrl }}
+            {{- end -}}
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -50,6 +50,8 @@ node:
                   - hybrid
   podInfoOnMountCompat:
     enable: false
+  # AWS S3 endpoint URL to use for all volume mounts (takes precedence over PV-level endpoint-url settings)
+  s3EndpointUrl: ""
 
 sidecars:
   nodeDriverRegistrar:

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - csidriver.yaml
   - node-daemonset.yaml
   - node-serviceaccount.yaml
+  - s3-csi-driver-config.yaml
 secretGenerator:
   - name: aws-credentials
     behavior: create

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -104,6 +104,12 @@ spec:
                   name: aws-secret
                   key: session_token
                   optional: true
+            # AWS S3 endpoint URL to use for all volume mounts
+            - name: AWS_ENDPOINT_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: s3-csi-driver-config
+                  key: s3-endpoint-url
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/deploy/kubernetes/base/s3-csi-driver-config.yaml
+++ b/deploy/kubernetes/base/s3-csi-driver-config.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s3-csi-driver-config
+  labels:
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+data:
+  # Uncomment and set the s3-endpoint-url if needed
+  # s3-endpoint-url: "https://s3.scality.com:8000"

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,3 +6,9 @@ images:
   - name: csi-driver
     newName: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
     newTag: v1.13.0
+# Uncomment to set the S3 endpoint URL
+# configMapGenerator:
+#   - name: s3-csi-driver-config
+#     behavior: merge
+#     literals:
+#       - s3-endpoint-url=https://s3.scality.com:8000

--- a/pkg/driver/node/envprovider/provider.go
+++ b/pkg/driver/node/envprovider/provider.go
@@ -13,6 +13,7 @@ const (
 	EnvDefaultRegion         = "AWS_DEFAULT_REGION"
 	EnvSTSRegionalEndpoints  = "AWS_STS_REGIONAL_ENDPOINTS"
 	EnvMaxAttempts           = "AWS_MAX_ATTEMPTS"
+	EnvEndpointURL           = "AWS_ENDPOINT_URL"
 	EnvProfile               = "AWS_PROFILE"
 	EnvConfigFile            = "AWS_CONFIG_FILE"
 	EnvSharedCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
@@ -40,6 +41,7 @@ var envAllowlist = []Key{
 	EnvRegion,
 	EnvDefaultRegion,
 	EnvSTSRegionalEndpoints,
+	EnvEndpointURL,
 }
 
 // Region returns detected region from environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.

--- a/pkg/driver/node/envprovider/provider_test.go
+++ b/pkg/driver/node/envprovider/provider_test.go
@@ -72,6 +72,17 @@ func TestProvidingDefaultEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
+			name: "s3 endpoint url env var set",
+			env: map[string]string{
+				"AWS_REGION":       "us-west-1",
+				"AWS_ENDPOINT_URL": "https://custom-endpoint.example.com",
+			},
+			want: []string{
+				"AWS_ENDPOINT_URL=https://custom-endpoint.example.com",
+				"AWS_REGION=us-west-1",
+			},
+		},
+		{
 			name: "additional env variables shouldn't be passed",
 			env: map[string]string{
 				"AWS_REGION":       "us-west-1",


### PR DESCRIPTION
Support is added to specify the S3 endpoint at the driver level.
Use case: This allows the Kubernetes administrator to decide the endpoint at the driver deployment level.

In this PR:
- We added the option to specify the endpoint at the CSI driver level, which will eventually be passed through to the Mountpount-s3.
- Added appropriate unit tests for the endpoint and both for systemdMounter and Pod mounter
- Updated helm chart to allow s3 endpoint specification using values.yaml
- Updated Kustomize to add an s3 endpoint using Kube configMap (it is intentional not to use a secret for the s3 endpoint)

More E2E tests coming soon:
[SystemdMounter Tests ticket](https://scality.atlassian.net/browse/S3CSI-7) 
[Performance Tests ticket](https://scality.atlassian.net/browse/S3CSI-8) 
[PodMounter Tests ticket](https://scality.atlassian.net/browse/S3CSI-9) 