### PR TITLE
S3CSI-9: Add Mount Options Test Suite for S3 CSI Driver

### DIFF
--- a/tests/e2e/customsuites/README.md
+++ b/tests/e2e/customsuites/README.md
@@ -1,0 +1,41 @@
+# Custom Test Suites for S3 CSI Driver
+
+This package provides test suites specific to the Scality S3 CSI driver. It extends the standard Kubernetes storage test framework with tests that validate Scality-specific functionality.
+
+## Test Suites
+
+### Mount Options Test Suite
+
+The mount options test suite (`mountoptions.go`) verifies that the S3 CSI driver correctly handles volume mount options related to permissions, user/group IDs, and access controls when mounting S3 buckets in Kubernetes pods. It includes tests for:
+
+- Access to volumes when mounted with non-root user/group IDs
+- Proper enforcement of permissions when mount options are absent
+- File and directory ownership when mounting with specific uid/gid
+
+### Utilities
+
+The `util.go` file contains utility functions that support all test suites:
+
+- Helpers for file operations (read/write/verify)
+- Pod configuration utilities
+- Volume resource creation with custom mount options
+
+## Adding New Test Suites
+
+When adding new test suites to this package, follow these guidelines:
+
+1. Create a new file named after the feature being tested (e.g., `multivolume.go`)
+2. Implement the storage framework's `TestSuite` interface
+3. Create an initializer function named `InitXXXTestSuite()`
+4. Register the new test suite in `tests/e2e/e2e_test.go`
+5. Add documentation for your test suite in this README
+
+## Running Tests
+
+Tests in this package are automatically executed as part of the [E2E test suite](../e2e_test.go) when running:
+
+```
+go test -v ./tests/e2e/...
+```
+
+See the [main project documentation](../README.md) for details on setting up the test environment with proper credentials and S3 endpoint configuration.

--- a/tests/e2e/customsuites/mountoptions.go
+++ b/tests/e2e/customsuites/mountoptions.go
@@ -1,0 +1,181 @@
+// This file implements the mount options test suite, which verifies that the S3 CSI
+// driver correctly handles volume mount options related to permissions, user/group IDs,
+// and access controls when mounting S3 buckets in Kubernetes pods.
+package customsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// Constants for user/group IDs used in non-root access tests.
+// These values must be different from root (0) and must match what's expected
+// by the test infrastructure.
+const (
+	defaultNonRootUser  = int64(1001)
+	defaultNonRootGroup = int64(2000)
+)
+
+// s3CSIMountOptionsTestSuite implements the Kubernetes storage framework TestSuite interface.
+// It validates that the S3 CSI driver properly handles various mount options, particularly
+// those related to file ownership, permissions, and access control.
+type s3CSIMountOptionsTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+// InitS3MountOptionsTestSuite initializes and returns a test suite that validates
+// mount options functionality for the S3 CSI driver.
+//
+// This suite specifically tests:
+// - Access to volumes when mounted with non-root user/group IDs
+// - Proper enforcement of permissions when mount options are absent
+// - File and directory ownership when mounting with specific uid/gid
+//
+// The test suite is registered with the E2E framework and will be automatically
+// executed when the test runner is invoked.
+func InitS3MountOptionsTestSuite() storageframework.TestSuite {
+	return &s3CSIMountOptionsTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "mountoptions",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+// GetTestSuiteInfo returns metadata about this test suite for the framework.
+func (t *s3CSIMountOptionsTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+// SkipUnsupportedTests allows test suites to skip certain tests based on driver capabilities.
+// For S3 mount options, all tests should be supported, so this is a no-op.
+func (t *s3CSIMountOptionsTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+// DefineTests implements the actual test suite functionality.
+// This method is called by the storage framework to execute the tests.
+func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	// local struct to maintain test state across BeforeEach/AfterEach/It blocks
+	type local struct {
+		resources []*storageframework.VolumeResource // tracks resources for cleanup
+		config    *storageframework.PerTestConfig    // storage framework configuration
+	}
+	var (
+		l local
+	)
+
+	// Create a framework with custom timeouts based on the driver's requirements
+	f := framework.NewFrameworkWithCustomTimeouts("mountoptions", storageframework.GetDriverTimeouts(driver))
+	// Use restricted pod security level to better represent real-world scenarios
+	f.NamespacePodSecurityLevel = admissionapi.LevelRestricted
+
+	// cleanup function to be called after each test to ensure resources are properly deleted
+	cleanup := func(ctx context.Context) {
+		var errs []error
+		for _, resource := range l.resources {
+			errs = append(errs, resource.CleanupResource(ctx))
+		}
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+	}
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		ginkgo.DeferCleanup(cleanup)
+	})
+
+	// validateWriteToVolume is a helper function that tests write access to a volume
+	// when mounted with specific options to allow non-root access.
+	//
+	// This function:
+	// 1. Creates a volume with mount options for non-root access
+	// 2. Creates a pod that runs as non-root and mounts this volume
+	// 3. Verifies the pod can write to and read from the volume
+	// 4. Checks that files and directories have correct ownership and permissions
+	//
+	// These checks validate that the S3 CSI driver correctly applies mount options
+	// like uid, gid, and allow-other to enable non-root access to S3 buckets.
+	validateWriteToVolume := func(ctx context.Context) {
+		// Create volume with mount options that should allow non-root access:
+		// - uid/gid set to non-root values
+		// - allow-other to permit access by users other than the mounter
+		// - debug flags for better logging in case of issues
+		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{
+			fmt.Sprintf("uid=%d", defaultNonRootUser),
+			fmt.Sprintf("gid=%d", defaultNonRootGroup),
+			"allow-other",
+			"debug",
+		})
+		l.resources = append(l.resources, resource)
+		ginkgo.By("Creating pod with a volume")
+		pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelRestricted, "")
+		podModifierNonRoot(pod)
+		var err error
+		pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+		volPath := "/mnt/volume1"
+		fileInVol := fmt.Sprintf("%s/file.txt", volPath)
+		seed := time.Now().UTC().UnixNano()
+		toWrite := 1024 // 1KB
+		ginkgo.By("Checking write to a volume")
+		checkWriteToPath(f, pod, fileInVol, toWrite, seed)
+		ginkgo.By("Checking read from a volume")
+		checkReadFromPath(f, pod, fileInVol, toWrite, seed)
+		ginkgo.By("Checking file group owner")
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '644 %d %d'", fileInVol, defaultNonRootGroup, defaultNonRootUser))
+		ginkgo.By("Checking dir group owner")
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '755 %d %d'", volPath, defaultNonRootGroup, defaultNonRootUser))
+		ginkgo.By("Checking pod identity")
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("id | grep 'uid=%d gid=%d groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
+	}
+	ginkgo.It("should access volume as a non-root user", func(ctx context.Context) {
+		validateWriteToVolume(ctx)
+	})
+
+	// accessVolAsNonRootUser is a helper function that tests that access is properly denied
+	// when mount options for non-root access are NOT provided.
+	//
+	// This function:
+	// 1. Creates a volume with NO special mount options
+	// 2. Creates a pod that runs as non-root and tries to access this volume
+	// 3. Verifies that access is denied due to lack of permissions
+	//
+	// This is security test to ensure volumes aren't accessible
+	// to non-root users unless explicitly configured to allow such access.
+	accessVolAsNonRootUser := func(ctx context.Context) {
+		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{})
+		l.resources = append(l.resources, resource)
+		ginkgo.By("Creating pod with a volume")
+		pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelRestricted, "")
+		podModifierNonRoot(pod)
+		var err error
+		pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+		volPath := "/mnt/volume1"
+		ginkgo.By("Checking file group owner")
+		_, stderr, err := e2evolume.PodExec(f, pod, fmt.Sprintf("ls %s", volPath))
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(stderr).To(gomega.ContainSubstring("Permission denied"))
+	}
+	ginkgo.It("should not be able to access volume as a non-root user", func(ctx context.Context) {
+		accessVolAsNonRootUser(ctx)
+	})
+}

--- a/tests/e2e/customsuites/util.go
+++ b/tests/e2e/customsuites/util.go
@@ -1,0 +1,202 @@
+// This file contains utility functions that support the mount options test suite.
+// It provides helpers for file operations, pod configuration, and PV/PVC creation
+// needed for testing S3 CSI driver mount functionality.
+package customsuites
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/rand"
+
+	"github.com/google/uuid"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	"k8s.io/utils/ptr"
+)
+
+// genBinDataFromSeed generates binary data with random seed for testing file operations.
+// This is useful for creating consistent test data that can be verified after read operations.
+//
+// Parameters:
+// - len: size of the data to generate in bytes
+// - seed: random seed to ensure reproducibility across test operations
+//
+// Returns a byte slice containing the generated data.
+func genBinDataFromSeed(len int, seed int64) []byte {
+	binData := make([]byte, len)
+	randLocal := rand.New(rand.NewSource(seed))
+
+	_, err := randLocal.Read(binData)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+
+	return binData
+}
+
+// checkWriteToPath writes data to a file in the pod and verifies it succeeded.
+// This function:
+// 1. Generates random data using the provided seed
+// 2. Encodes it to base64 for safe transmission to the pod
+// 3. Executes commands in the pod to write the data to the specified path
+// 4. Verifies the operation succeeded
+//
+// This is a core test utility for validating write access to mounted volumes.
+func checkWriteToPath(f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
+	data := genBinDataFromSeed(toWrite, seed)
+	encoded := base64.StdEncoding.EncodeToString(data)
+	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | sha256sum", encoded))
+	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite))
+	framework.Logf("written data with sha: %x", sha256.Sum256(data))
+}
+
+// checkReadFromPath reads data from a file in the pod and verifies its content.
+// This function:
+// 1. Calculates the expected SHA256 hash based on the same seed used for writing
+// 2. Reads the file content in the pod
+// 3. Computes a hash of the content
+// 4. Verifies the hash matches the expected value
+//
+// This ensures that data integrity is maintained throughout volume operations.
+func checkReadFromPath(f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
+	sum := sha256.Sum256(genBinDataFromSeed(toWrite, seed))
+	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum", path, toWrite))
+	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum))
+}
+
+// podModifierNonRoot modifies a pod to run as a non-root user.
+// This utility function:
+// 1. Configures the pod's security context to use non-root user/group IDs
+// 2. Sets the RunAsNonRoot flag to enforce non-root execution
+// 3. Applies the same settings to all containers in the pod
+//
+// This is essential for testing permission boundaries and security aspects
+// of volume mounts, ensuring they respect proper access controls.
+func podModifierNonRoot(pod *v1.Pod) {
+	if pod.Spec.SecurityContext == nil {
+		pod.Spec.SecurityContext = &v1.PodSecurityContext{}
+	}
+	pod.Spec.SecurityContext.RunAsUser = ptr.To(defaultNonRootUser)
+	pod.Spec.SecurityContext.RunAsGroup = ptr.To(defaultNonRootGroup)
+	pod.Spec.SecurityContext.RunAsNonRoot = ptr.To(true)
+
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].SecurityContext == nil {
+			pod.Spec.Containers[i].SecurityContext = &v1.SecurityContext{}
+		}
+		pod.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To(defaultNonRootUser)
+		pod.Spec.Containers[i].SecurityContext.RunAsGroup = ptr.To(defaultNonRootGroup)
+		pod.Spec.Containers[i].SecurityContext.RunAsNonRoot = ptr.To(true)
+	}
+}
+
+// createPod creates a pod with PVC mounts and waits for it to be running.
+// This function:
+// 1. Submits the pod creation request to the Kubernetes API
+// 2. Waits for the pod to reach Running state
+// 3. Fetches the latest pod information after it's running
+//
+// This utility handles common pod creation patterns needed for volume testing,
+// ensuring pods are fully ready before tests proceed to volume operations.
+func createPod(ctx context.Context, client clientset.Interface, namespace string, pod *v1.Pod) (*v1.Pod, error) {
+	framework.Logf("Creating Pod %s in %s", pod.Name, namespace)
+	pod, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("pod Create API error: %w", err)
+	}
+	// Waiting for pod to be running
+	err = e2epod.WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)
+	if err != nil {
+		return pod, fmt.Errorf("pod %q is not Running: %w", pod.Name, err)
+	}
+	// get fresh pod info
+	pod, err = client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return pod, fmt.Errorf("pod Get API error: %w", err)
+	}
+	return pod, nil
+}
+
+// createVolumeResourceWithMountOptions creates a volume resource with specified mount options.
+// This function extends the standard Kubernetes storage framework volume creation by:
+// 1. Creating an S3 bucket via the driver's CreateVolume method
+// 2. Setting up a PV with the specified mount options (crucial for S3 CSI testing)
+// 3. Creating a matching PVC that binds to this PV
+// 4. Waiting for the binding to complete
+//
+// The mount options parameter is key for testing various S3-specific mount behaviors,
+// allowing tests to validate permissions, caching, and other mount parameters.
+//
+// This function is a critical extension point as the standard storage framework
+// does not support mount options out of the box.
+func createVolumeResourceWithMountOptions(ctx context.Context, config *storageframework.PerTestConfig, pattern storageframework.TestPattern, mountOptions []string) *storageframework.VolumeResource {
+	f := config.Framework
+	r := storageframework.VolumeResource{
+		Config:  config,
+		Pattern: pattern,
+	}
+	pDriver, _ := config.Driver.(storageframework.PreprovisionedPVTestDriver)
+	r.Volume = pDriver.CreateVolume(ctx, config, storageframework.PreprovisionedPV)
+	pvSource, volumeNodeAffinity := pDriver.GetPersistentVolumeSource(false, "", r.Volume)
+
+	pvName := fmt.Sprintf("s3-e2e-pv-%s", uuid.New().String())
+	pvcName := fmt.Sprintf("s3-e2e-pvc-%s", uuid.New().String())
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: *pvSource,
+			StorageClassName:       "", // for static provisioning
+			NodeAffinity:           volumeNodeAffinity,
+			MountOptions:           mountOptions, // this is not set by kubernetes storageframework.CreateVolumeResource, which is why we need this function
+			AccessModes:            []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			ClaimRef: &v1.ObjectReference{
+				Name:      pvcName,
+				Namespace: f.Namespace.Name,
+			},
+		},
+	}
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: f.Namespace.Name,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: ptr.To(""), // for static provisioning
+			VolumeName:       pvName,
+			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	framework.Logf("Creating PVC and PV")
+	var err error
+
+	r.Pv, err = f.ClientSet.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "PV creation failed")
+
+	r.Pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "PVC creation failed")
+
+	err = e2epv.WaitOnPVandPVC(ctx, f.ClientSet, f.Timeouts, f.Namespace.Name, r.Pv, r.Pvc)
+	framework.ExpectNoError(err, "PVC, PV failed to bind")
+	return &r
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/customsuites"
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
+
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 	f "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
@@ -64,7 +66,9 @@ var CSITestSuites = []func() framework.TestSuite{
 	// This is part of the standard CSI driver compliance test suite and is
 	// used to verify functional support for static provisioning with S3 storage.
 	testsuites.InitVolumesTestSuite,
-	// TODO(S3CSI-9): Add custom Scality specific test suites here.
+
+	// Custom test suites specific to Scality S3 CSI driver.
+	customsuites.InitS3MountOptionsTestSuite,
 }
 
 // initS3Driver initializes and returns an S3 CSI driver implementation for E2E testing.


### PR DESCRIPTION
Introduces mount point s3 test suite to test mountpoint options and file system permissions on S3 buckets

Why is this needed?
These tests ensure that the CSI driver correctly implements mount options, which are essential for secure multi-user access to S3 buckets in Kubernetes environments. The tests verify both the positive case (access works with correct options) and negative case (access is denied without proper options).

Mostly inspired from AWS mountpoint-s3 test suite.
Based on [main PR](https://github.com/scality/mountpoint-s3-csi-driver/pull/19)