### PR TITLE
S3CSI-10: Update organization references from awslabs to scality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
 FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.24-bullseye as builder
 ARG TARGETARCH
 
-WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver
+WORKDIR /go/src/github.com/scality/mountpoint-s3-csi-driver
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     TARGETARCH=${TARGETARCH} make bin
@@ -65,10 +65,10 @@ COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
 
 # Copy CSI Driver binaries
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/scality-s3-csi-driver /bin/scality-s3-csi-driver
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/scality-csi-controller /bin/scality-csi-controller
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/scality-s3-csi-mounter /bin/scality-s3-csi-mounter
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/scality-s3-csi-driver /bin/scality-s3-csi-driver
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/scality-csi-controller /bin/scality-csi-controller
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/scality-s3-csi-mounter /bin/scality-s3-csi-mounter
 # TODO: This won't be necessary with containerization.
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
 
 ENTRYPOINT ["/bin/scality-s3-csi-driver"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -49,7 +49,7 @@ RUN cd mountpoint-s3 && \
 FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.24-bullseye as builder
 ARG TARGETARCH
 
-WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver
+WORKDIR /go/src/github.com/scality/mountpoint-s3-csi-driver
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     TARGETARCH=${TARGETARCH} make bin
@@ -72,10 +72,10 @@ COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
 
 # Copy CSI Driver binaries
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/scality-s3-csi-driver /bin/scality-s3-csi-driver
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/scality-csi-controller /bin/scality-csi-controller
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/scality-s3-csi-mounter /bin/scality-s3-csi-mounter
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/scality-s3-csi-driver /bin/scality-s3-csi-driver
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/scality-csi-controller /bin/scality-csi-controller
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/scality-s3-csi-mounter /bin/scality-s3-csi-mounter
 # TODO: This won't be necessary with containerization.
-COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
+COPY --from=builder /go/src/github.com/scality/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
 
 ENTRYPOINT ["/bin/scality-s3-csi-driver"]

--- a/README.md
+++ b/README.md
@@ -12,30 +12,30 @@ For Amazon EKS clusters, the Mountpoint for Amazon S3 CSI driver is also availab
 Mountpoint for Amazon S3 does not implement all the features of a POSIX file system, and there are some differences that may affect compatibility with your application. See [Mountpoint file system behavior](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md) for a detailed description of Mountpoint's behavior and POSIX support and how they could affect your application.
 
 ## Container Images
-| Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver) Image |
+| Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|
-| v1.13.0        | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.13.0                      |
+| v1.13.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.13.0                      |
 
 <details>
 <summary>Previous Images</summary>
 
-| Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver) Image |
+| Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|
-| v1.12.0        | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.12.0                      |
-| v1.11.0        | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.11.0                      |
-| v1.10.0        | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.10.0                      |
-| v1.9.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.9.0                       |
-| v1.8.1         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.8.1                       |
-| v1.8.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.8.0                       |
-| v1.7.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.7.0                       |
-| v1.6.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.6.0                       |
-| v1.5.1         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.5.1                       |
-| v1.4.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.4.0                       |
-| v1.3.1         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.3.1                       |
-| v1.3.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.3.0                       |
-| v1.2.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.2.0                       |
-| v1.1.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.1.0                       |
-| v1.0.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.0.0                       |
+| v1.12.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.12.0                      |
+| v1.11.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.11.0                      |
+| v1.10.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.10.0                      |
+| v1.9.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.9.0                       |
+| v1.8.1         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.8.1                       |
+| v1.8.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.8.0                       |
+| v1.7.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.7.0                       |
+| v1.6.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.6.0                       |
+| v1.5.1         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.5.1                       |
+| v1.4.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.4.0                       |
+| v1.3.1         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.3.1                       |
+| v1.3.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.3.0                       |
+| v1.2.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.2.0                       |
+| v1.1.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.1.0                       |
+| v1.0.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.0.0                       |
 </details>
 
 ## Releases

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -7,7 +7,7 @@ home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:
   - https://github.com/scality/mountpoint-s3-csi-driver
 keywords:
-  - aws
+  - scality
   - mountpoint
   - s3
   - csi

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
-name: aws-mountpoint-s3-csi-driver
+name: scality-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Amazon S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
 version: 1.13.0
 kubeVersion: ">=1.23.0-0"
-home: https://github.com/awslabs/mountpoint-s3-csi-driver
+home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:
-  - https://github.com/awslabs/mountpoint-s3-csi-driver
+  - https://github.com/scality/mountpoint-s3-csi-driver
 keywords:
   - aws
   - mountpoint
   - s3
   - csi
 maintainers:
-  - name: AWS S3
-    url: https://github.com/awslabs/mountpoint-s3-csi-driver
+  - name: Scality Inc.
+    url: https://github.com/scality/mountpoint-s3-csi-driver

--- a/charts/scality-mountpoint-s3-csi-driver/templates/_helpers.tpl
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "aws-mountpoint-s3-csi-driver.name" -}}
+{{- define "scality-mountpoint-s3-csi-driver.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "aws-mountpoint-s3-csi-driver.fullname" -}}
+{{- define "scality-mountpoint-s3-csi-driver.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,17 +27,17 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "aws-mountpoint-s3-csi-driver.chart" -}}
+{{- define "scality-mountpoint-s3-csi-driver.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "aws-mountpoint-s3-csi-driver.labels" -}}
-{{ include "aws-mountpoint-s3-csi-driver.selectorLabels" . }}
+{{- define "scality-mountpoint-s3-csi-driver.labels" -}}
+{{ include "scality-mountpoint-s3-csi-driver.selectorLabels" . }}
 {{- if ne .Release.Name "kustomize" }}
-helm.sh/chart: {{ include "aws-mountpoint-s3-csi-driver.chart" . }}
+helm.sh/chart: {{ include "scality-mountpoint-s3-csi-driver.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -52,8 +52,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Common selector labels
 */}}
-{{- define "aws-mountpoint-s3-csi-driver.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "aws-mountpoint-s3-csi-driver.name" . }}
+{{- define "scality-mountpoint-s3-csi-driver.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "scality-mountpoint-s3-csi-driver.name" . }}
 {{- if ne .Release.Name "kustomize" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
@@ -62,7 +62,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Convert the `--extra-tags` command line arg from a map.
 */}}
-{{- define "aws-mountpoint-s3-csi-driver.extra-volume-tags" -}}
+{{- define "scality-mountpoint-s3-csi-driver.extra-volume-tags" -}}
 {{- $result := dict "pairs" (list) -}}
 {{- range $key, $value := .Values.controller.extraVolumeTags -}}
 {{- $noop := printf "%s=%v" $key $value | append $result.pairs | set $result "pairs" -}}

--- a/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -6,18 +6,18 @@ metadata:
   name: s3-csi-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: s3-csi-controller
-      {{- include "aws-mountpoint-s3-csi-driver.selectorLabels" . | nindent 6 }}
+      {{- include "scality-mountpoint-s3-csi-driver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: s3-csi-controller
-        {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
+        {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -45,7 +45,7 @@ spec:
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - "/bin/aws-s3-csi-controller"
+            - "/bin/scality-s3-csi-controller"
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/charts/scality-mountpoint-s3-csi-driver/templates/csidriver.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/csidriver.yaml
@@ -3,7 +3,7 @@ kind: CSIDriver
 metadata:
   name: s3.csi.scality.com
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
   attachRequired: false
   {{- if or (.Values.node.podInfoOnMountCompat.enable) (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.Version) }}

--- a/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
@@ -4,17 +4,17 @@ metadata:
   name: s3-csi-node
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
       app: s3-csi-node
-      {{- include "aws-mountpoint-s3-csi-driver.selectorLabels" . | nindent 6 }}
+      {{- include "scality-mountpoint-s3-csi-driver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: s3-csi-node
-        {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
+        {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.controller.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,7 +19,7 @@ metadata:
   name: s3-csi-driver-controller-role
   namespace: {{ .Values.mountpointPod.namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -31,7 +31,7 @@ metadata:
   name: s3-csi-driver-controller-role-binding
   namespace: {{ .Values.mountpointPod.namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount.name }}
@@ -46,7 +46,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: s3-csi-driver-controller-cluster-role
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "persistentvolumeclaims", "persistentvolumes"]
@@ -57,7 +57,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: s3-csi-driver-controller-cluster-role-binding
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount.name }}

--- a/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.node.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.node.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: s3-csi-driver-cluster-role
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
@@ -31,7 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: mountpoint-s3-csi-node-binding
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.node.serviceAccount.name }}
@@ -49,7 +49,7 @@ metadata:
   name: s3-csi-driver-node-mountpoint-pod-namespace-role
   namespace: {{ .Values.mountpointPod.namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -61,7 +61,7 @@ metadata:
   name: s3-csi-driver-node-mountpoint-pod-namespace-role-binding
   namespace: {{ .Values.mountpointPod.namespace }}
   labels:
-    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+    {{- include "scality-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.node.serviceAccount.name }}

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # Our regional ECR repositories are labelled `eks/aws-s3-csi-driver`.
+  # Our regional ECR repositories are labelled `eks/scality-s3-csi-driver`.
   # See https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html for the per-region registry list.
-  # Example: `602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/aws-s3-csi-driver` for us-east-1.
-  repository: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
+  # Example: `602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/scality-s3-csi-driver` for us-east-1.
+  repository: public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v1.13.0"

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -4,17 +4,17 @@ apiVersion: apps/v1
 metadata:
   name: s3-csi-node
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 spec:
   selector:
     matchLabels:
       app: s3-csi-node
-      app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+      app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
   template:
     metadata:
       labels:
         app: s3-csi-node
-        app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+        app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/deploy/kubernetes/base/node-serviceaccount.yaml
+++ b/deploy/kubernetes/base/node-serviceaccount.yaml
@@ -5,14 +5,14 @@ kind: ServiceAccount
 metadata:
   name: s3-csi-driver-sa
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: s3-csi-driver-cluster-role
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
@@ -23,7 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: mountpoint-s3-csi-node-binding
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 subjects:
   - kind: ServiceAccount
     name: s3-csi-driver-sa

--- a/deploy/kubernetes/base/s3-csi-driver-config.yaml
+++ b/deploy/kubernetes/base/s3-csi-driver-config.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: s3-csi-driver-config
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
 data:
   dummy: "" # This ensures data is a proper object even when no values are set
   # Uncomment and set the s3-endpoint-url if needed

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../base
 images:
   - name: csi-driver
-    newName: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
+    newName: public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver
     newTag: v1.13.0
 # Uncomment to set the S3 endpoint URL
 # configMapGenerator:

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,26 +25,26 @@ You may deploy the Mountpoint for Amazon S3 CSI driver via Kustomize, Helm.
 
 <!-- TODO(S3CSI-17): Add helm installation steps -->
 
-Review the [configuration values](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/charts/aws-mountpoint-s3-csi-driver/values.yaml) for the Helm chart.
+Review the [configuration values](https://github.com/scality/mountpoint-s3-csi-driver/blob/main/charts/scality-mountpoint-s3-csi-driver/values.yaml) for the Helm chart.
 
 #### Once the driver has been deployed, verify the pods are running:
 ```sh
-kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-mountpoint-s3-csi-driver
+kubectl get pods -n kube-system -l app.kubernetes.io/name=scality-mountpoint-s3-csi-driver
 ```
 
 ### Volume Configuration Example
-Follow the [README for examples](https://github.com/awslabs/mountpoint-s3-csi-driver/tree/main/examples/kubernetes/static_provisioning) on using the driver.
+Follow the [README for examples](https://github.com/scality/mountpoint-s3-csi-driver/tree/main/examples/kubernetes/static_provisioning) on using the driver.
 
 ### Uninstalling the driver
 
 #### Helm
 
 ```
-helm uninstall aws-mountpoint-s3-csi-driver --namespace kube-system
+helm uninstall scality-mountpoint-s3-csi-driver --namespace kube-system
 ```
 
 #### Kustomize
 
 ```
-kubectl delete -k "github.com/awslabs/mountpoint-s3-csi-driver/deploy/kubernetes/overlays/stable/?ref=<YOUR-CSI-DRIVER-VERION-NUMBER>"
+kubectl delete -k "github.com/scality/mountpoint-s3-csi-driver/deploy/kubernetes/overlays/stable/?ref=<YOUR-CSI-DRIVER-VERION-NUMBER>"
 ```

--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -24,13 +24,13 @@ node:
 ```
 
 ## Configure
-### Edit [Persistent Volume](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/examples/kubernetes/static_provisioning/static_provisioning.yaml)
+### Edit [Persistent Volume](https://github.com/scality/mountpoint-s3-csi-driver/blob/main/examples/kubernetes/static_provisioning/static_provisioning.yaml)
 > Note: This example assumes your S3 bucket has already been created. If you need to create a bucket, follow the [S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html) for a general purpose bucket or the [S3 Express One Zone documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-create.html) for a directory bucket.
 - Bucket name (required): `PersistentVolume -> csi -> volumeAttributes -> bucketName`
 - Bucket region (if bucket and cluster are in different regions): `PersistentVolume -> csi -> mountOptions`
 - [Mountpoint configurations](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md) can be added in the `mountOptions` of the Persistent Volume spec.
 
-See [Static Provisioning](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#static-provisioning) configuration page for more details.
+See [Static Provisioning](https://github.com/scality/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#static-provisioning) configuration page for more details.
 
 ## Deploy
 ```

--- a/examples/kubernetes/static_provisioning/pod_level_identity.yaml
+++ b/examples/kubernetes/static_provisioning/pod_level_identity.yaml
@@ -75,7 +75,7 @@ kind: ServiceAccount
 metadata:
   name: s3-csi-admin-sa
   labels:
-    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: scality-mountpoint-s3-csi-driver
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::<user_id>:role/Admin"
 ---

--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -23,8 +23,8 @@ const (
 	serviceAccountRoleAnnotation   = "eks.amazonaws.com/role-arn"
 )
 
-const podLevelCredentialsDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials"
-const stsConfigDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#configuring-the-sts-region"
+const podLevelCredentialsDocsPage = "https://github.com/scality/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials"
+const stsConfigDocsPage = "https://github.com/scality/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#configuring-the-sts-region"
 
 type serviceAccountToken struct {
 	Token               string    `json:"token"`


### PR DESCRIPTION
This PR updates all references from `awslabs` to `scality` across the codebase, including Dockerfiles, Helm charts, Kubernetes deployments, documentation, and code. This change aligns with the organization's branding and repository ownership.


#### Changes Made
1. **Dockerfile Updates**
   - Updated WORKDIR paths in Dockerfile and Dockerfile.local
   - Updated COPY paths for CSI driver binaries
   - Changed organization references from awslabs to scality

2. **Helm Chart Updates**
   - Updated chart name and maintainer information
   - Updated template references and labels
   - Changed image repository paths
   - Updated values.yaml with new repository references

3. **Kubernetes Deployment Updates**
   - Updated node daemonset labels
   - Updated service account configurations
   - Updated CSI driver config map
   - Updated kustomization.yaml with new image paths

4. **Documentation Updates**
   - Updated README.md with new repository references
   - Updated installation documentation
   - Updated example configurations
   - Updated documentation links and references

5. **Code Updates**
   - Updated documentation URLs in provider_pod.go
   - Changed references from awslabs to scality
