### PR TITLE
S3CSI-22: release version 0.1.0 and delete AWS specific docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# Mountpoint for Amazon S3 CSI Driver
+# Mountpoint for Scality's fork of Amazon S3 CSI Driver
 
 ## Overview
-The Mountpoint for Amazon S3 Container Storage Interface (CSI) Driver allows your Kubernetes applications to access Amazon S3 objects through a file system interface. Built on [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3), the Mountpoint CSI driver presents an Amazon S3 bucket as a storage volume accessible by containers in your Kubernetes cluster. The Mountpoint CSI driver implements the [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) specification for container orchestrators (CO) to manage storage volumes.
-
-For Amazon EKS clusters, the Mountpoint for Amazon S3 CSI driver is also available as an [EKS add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) to provide automatic installation and management.
+The Mountpoint for Scality S3 Container Storage Interface (CSI) Driver allows your Kubernetes applications to access Scality S3 objects through a file system interface. Built on [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3), the Mountpoint CSI driver presents a Scality S3 bucket as a storage volume accessible by containers in your Kubernetes cluster. The Mountpoint CSI driver implements the [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) specification for container orchestrators (CO) to manage storage volumes.
 
 ## Features
 * **Static Provisioning** - Associate an existing S3 bucket with a [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PV) for consumption within Kubernetes.
@@ -12,31 +10,9 @@ For Amazon EKS clusters, the Mountpoint for Amazon S3 CSI driver is also availab
 Mountpoint for Amazon S3 does not implement all the features of a POSIX file system, and there are some differences that may affect compatibility with your application. See [Mountpoint file system behavior](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md) for a detailed description of Mountpoint's behavior and POSIX support and how they could affect your application.
 
 ## Container Images
-| Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver) Image |
-|----------------|---------------------------------------------------------------------------------------------------|
-| v1.13.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.13.0                      |
-
-<details>
-<summary>Previous Images</summary>
-
-| Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver) Image |
-|----------------|---------------------------------------------------------------------------------------------------|
-| v1.12.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.12.0                      |
-| v1.11.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.11.0                      |
-| v1.10.0        | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.10.0                      |
-| v1.9.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.9.0                       |
-| v1.8.1         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.8.1                       |
-| v1.8.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.8.0                       |
-| v1.7.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.7.0                       |
-| v1.6.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.6.0                       |
-| v1.5.1         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.5.1                       |
-| v1.4.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.4.0                       |
-| v1.3.1         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.3.1                       |
-| v1.3.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.3.0                       |
-| v1.2.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.2.0                       |
-| v1.1.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.1.0                       |
-| v1.0.0         | public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver:v1.0.0                       |
-</details>
+| Driver Version | [GHCR Public](https://github.com/scality/mountpoint-s3-csi-driver/pkgs/container/mountpoint-s3-csi-driver) Image |
+|----------------|-----------------------------------------------------------------------------------------------------------------|
+| v0.1.0         | ghcr.io/scality/mountpoint-s3-csi-driver                                                                        |
 
 ## Releases
 The Mountpoint for S3 CSI Driver follows [semantic versioning](https://semver.org/). The version will be bumped following the rules below:
@@ -44,8 +20,6 @@ The Mountpoint for S3 CSI Driver follows [semantic versioning](https://semver.or
 * Significant breaking changes will be released as a `MAJOR` update.
 * New features will be released as a `MINOR` update.
 * Bug or vulnerability fixes will be released as a `PATCH` update.
-
-Monthly releases will contain at minimum a `MINOR` version bump, even if the content would normally be treated as a `PATCH` version.
 
 ## Compatibility
 

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: scality-mountpoint-s3-csi-driver
-description: A Helm chart for installing the Mountpoint for Amazon S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
-version: 1.13.0
+description: A Helm chart for installing the Mountpoint for Scality S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
+version: 0.1.0
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -3,13 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # Our regional ECR repositories are labelled `eks/scality-s3-csi-driver`.
-  # See https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html for the per-region registry list.
-  # Example: `602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/scality-s3-csi-driver` for us-east-1.
-  repository: public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver
+  repository: ghcr.io/scality/mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.13.0"
+  tag: "0.1.0"
 
 node:
   kubeletPath: /var/lib/kubelet

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,8 +4,8 @@ resources:
   - ../../base
 images:
   - name: csi-driver
-    newName: public.ecr.aws/mountpoint-s3-csi-driver/scality-mountpoint-s3-csi-driver
-    newTag: v1.13.0
+    newName: ghcr.io/scality/mountpoint-s3-csi-driver
+    newTag: 0.1.0
 # Uncomment to set the S3 endpoint URL
 # configMapGenerator:
 #   - name: s3-csi-driver-config


### PR DESCRIPTION
Release new version 
- Update references and images for Scality Infra
Sample release from this branch: https://github.com/scality/mountpoint-s3-csi-driver/actions/runs/14667193788