### PR TITLE
S3CSI-24: Use memory based empty directory

### DIFF
--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/cluster"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -18,6 +19,8 @@ const (
 	LabelVolumeName        = "s3.csi.scality.com/volume-name"
 	LabelCSIDriverVersion  = "s3.csi.scality.com/mounted-by-csi-driver-version"
 )
+
+const EmptyDirSizeLimit = 10 * 1024 * 1024 // 10MiB
 
 // A ContainerConfig represents configuration for containers in the spawned Mountpoint Pods.
 type ContainerConfig struct {
@@ -126,7 +129,10 @@ func (c *Creator) Create(pod *corev1.Pod, pv *corev1.PersistentVolume) *corev1.P
 				{
 					Name: CommunicationDirName,
 					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium:    corev1.StorageMediumMemory,
+							SizeLimit: resource.NewQuantity(EmptyDirSizeLimit, resource.BinarySI),
+						},
 					},
 				},
 			},

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -61,7 +62,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 			{
 				Name: mppod.CommunicationDirName,
 				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium:    corev1.StorageMediumMemory,
+						SizeLimit: resource.NewQuantity(mppod.EmptyDirSizeLimit, resource.BinarySI),
+					},
 				},
 			},
 		}, mpPod.Spec.Volumes)


### PR DESCRIPTION
Use a memory-based empty directory instead of disk based as empty directory is not really relevant in S3 object storage and Mountpoint-s3 does [not really support it](https://github.com/awslabs/mountpoint-s3/blob/main/doc%2FTROUBLESHOOTING.md#directory-disappears-after-deleting-all-the-files-within-it)
