### PR TITLE
S3CSI-25: Enable setting resource limits for init container

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
@@ -70,6 +70,9 @@ spec:
           volumeMounts:
             - name: mp-install
               mountPath: /target
+          {{- with default .Values.node.resources .Values.initContainer.installMountpoint.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
 
       containers:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -77,6 +77,11 @@ sidecars:
         name: plugin-dir
     resources: {}
 
+
+initContainer:
+  installMountpoint:
+    resources: {}
+
 controller:
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
Enabling setting resource limits, for now, we are not setting any, we will do it post-performance testing.
This only will allow users to set it.