### PR TITLE
S3CSI-11: Enhance Credential Handling(allow lower case AK) and Add Credentials E2E Test Suite for S3 CSI Driver

### DIFF
--- a/.github/actions/e2e-setup-common/action.yaml
+++ b/.github/actions/e2e-setup-common/action.yaml
@@ -26,6 +26,10 @@ runs:
         go-version-file: "tests/e2e/go.mod"
         cache: true
 
+    - name: Install Ginkgo CLI
+      shell: bash
+      run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
     - name: Create Kind Cluster
       uses: helm/kind-action@v1.12.0
       with:

--- a/pkg/driver/node/credentialprovider/provider_secret.go
+++ b/pkg/driver/node/credentialprovider/provider_secret.go
@@ -32,7 +32,8 @@ Validation rules (loosened for cloudserver test credentials):
 The patterns are supersets of AWS IAM and permit shorter dummy keys.
 */
 var (
-	accessKeyIDRe     = regexp.MustCompile(`^[A-Z0-9]{1,` + strconv.Itoa(maxAccessKeyIDLen) + `}$`)
+	// accept upper‑ or lower‑case letters so test keys like "accessKey2" pass
+	accessKeyIDRe     = regexp.MustCompile(`^[A-Za-z0-9]{1,` + strconv.Itoa(maxAccessKeyIDLen) + `}$`)
 	secretAccessKeyRe = regexp.MustCompile(`^[A-Za-z0-9/+=]{1,` + strconv.Itoa(maxSecretAccessKeyLen) + `}$`)
 )
 
@@ -54,7 +55,7 @@ func (c *Provider) provideFromSecret(_ context.Context, provideCtx ProvideContex
 	if okID {
 		id = strings.TrimSpace(id)
 		if !accessKeyIDRe.MatchString(id) {
-			klog.Warningf("credentialprovider: key_id %q is not uppercase alphanumeric or exceeds %d chars",
+			klog.Warningf("credentialprovider: key_id %q is not alphanumeric or exceeds %d chars",
 				id, maxAccessKeyIDLen)
 			okID = false
 		}

--- a/tests/e2e/customsuites/README.md
+++ b/tests/e2e/customsuites/README.md
@@ -66,6 +66,20 @@ The directory permissions test suite (`directorypermissions.go`) validates direc
 
 This suite ensures that directory permissions are correctly applied and maintained across various usage scenarios, providing proper access control for directory structures within S3 volumes.
 
+### Credentials Test Suite
+
+The credentials test suite (`credentials.go`) validates authentication and authorization behavior for the S3 CSI driver, covering both successful mounts (default and secret‐mounted credentials) and expected failure modes.
+
+**Credentials Tests:**
+
+- Default driver credentials Usage: Mount with the built-in access key/secret → write an object → verify owner ID matches the driver’s canonical ID (Bart)  
+- Secret-mounted volume credentials: Provide access key/secret via a Kubernetes Secret (`authenticationSource=secret`) → mount → write an object → verify owner ID matches the Secret’s canonical ID (Lisa)  
+
+**Error & Negative Tests:**
+
+- Invalid access key: Mount with a non-existent key → expect “access key Id does not exist” error  
+- Unauthorized credentials: Mount with valid key but no bucket permissions → expect “Access Denied Error: Failed to create mount process” failure  
+
 ### Multi-Volume Test Suite
 
 The multi-volume test suite (`multivolume.go`) validates scenarios involving multiple volumes and pods to ensure the S3 CSI driver properly handles concurrent access and volume isolation. It includes tests for:

--- a/tests/e2e/customsuites/cache.go
+++ b/tests/e2e/customsuites/cache.go
@@ -269,7 +269,7 @@ func bucketNameFromVolumeResource(vol *storageframework.VolumeResource) string {
 // This is useful to create side-effects by bypassing Mountpoint to test cache behavior
 // when objects are removed from the underlying S3 storage.
 func deleteObjectFromS3(ctx context.Context, bucket string, key string) {
-	client := s3client.New()
+	client := s3client.New("", "", "")
 	err := client.DeleteObject(ctx, bucket, key)
 	framework.ExpectNoError(err)
 }

--- a/tests/e2e/customsuites/credentials.go
+++ b/tests/e2e/customsuites/credentials.go
@@ -1,0 +1,360 @@
+package customsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
+)
+
+const (
+	// Lisa's real test credentials per cloudserver without Vault
+	lisaAK  = "accessKey2"
+	lisaSK  = "verySecretKey2"
+	lisaCID = "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf"
+
+	// Bart's canonical ID. Bart's credentials are being used in the tests
+	bartAK  = "accessKey1"
+	bartSK  = "verySecretKey1"
+	bartCID = "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+)
+
+// NegativeCredentialTestSpec defines parameters for a negative credential test.
+type NegativeCredentialTestSpec struct {
+	BucketOwnerAK, BucketOwnerSK string // Credentials used to create the bucket
+	PodAK, PodSK                 string // Credentials used in pod (should fail)
+	ErrorPattern                 string // Error message to expect
+	TestDescription              string // Human-readable test description
+	CustomPodName                string // Optional custom pod name (defaults to "test-credentials-error-{uuid}")
+}
+
+// RunNegativeCredentialsTest runs a standard test to verify credentials error handling.
+// It uses bucket owner's credentials to create a bucket, then attempts to access it
+// using the pod credentials, which should fail with the expected error pattern.
+func RunNegativeCredentialsTest(
+	ctx context.Context,
+	f *framework.Framework,
+	driver storageframework.TestDriver,
+	pattern storageframework.TestPattern,
+	spec NegativeCredentialTestSpec,
+) {
+	// 1. Create a bucket with bucket owner's credentials
+	ownerS3Client := s3client.New("", spec.BucketOwnerAK, spec.BucketOwnerSK)
+	bucketName, deleteBucket := ownerS3Client.CreateBucket(ctx)
+	ginkgo.DeferCleanup(deleteBucket)
+	framework.Logf("Created bucket %s with bucket owner's credentials", bucketName)
+
+	// 2. Create a secret with pod's credentials
+	secretName, err := CreateCredentialSecret(ctx, f, "credentials-test", spec.PodAK, spec.PodSK)
+	framework.ExpectNoError(err, "Failed to create secret with test credentials")
+
+	// 3. Build PV/PVC that uses the secret
+	cfg := driver.PrepareTest(ctx, f)
+	volumeResource := CreateVolumeWithSecretReference(
+		ctx,
+		cfg,
+		pattern,
+		secretName,
+		f.Namespace.Name,
+		bucketName,
+	)
+
+	// 4. Create a non-root pod with the volume - should fail with expected error
+	ginkgo.By(fmt.Sprintf("Creating pod with credentials that should fail: %s", spec.TestDescription))
+
+	// Create pod with unique name
+	podName := spec.CustomPodName
+	if podName == "" {
+		podName = "test-credentials-error-" + uuid.NewString()[:8]
+	}
+	framework.Logf("Creating pod %s in namespace %s", podName, f.Namespace.Name)
+
+	pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{volumeResource.Pvc}, admissionapi.LevelRestricted, "")
+	pod.Name = podName
+	podModifierNonRoot(pod)
+
+	// Create the pod
+	pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "Failed to create pod")
+	framework.Logf("Pod %s created successfully, now waiting for error event", pod.Name)
+
+	// 5. Wait for expected error pattern
+	ginkgo.By(fmt.Sprintf("Waiting for error: %q", spec.ErrorPattern))
+	framework.ExpectNoError(WaitForPodError(ctx, f, pod.Name, spec.ErrorPattern, 1*time.Minute))
+
+	framework.Logf("Test complete - found expected error")
+
+	// 6. Clean up pod
+	framework.Logf("Cleaning up pod %s", pod.Name)
+	framework.ExpectNoError(CleanupPodInErrorState(ctx, f, pod.Name))
+}
+
+// Test‑suite boilerplate
+type s3CSICredentialsSuite struct {
+	info storageframework.TestSuiteInfo
+}
+
+func InitS3CredentialsTestSuite() storageframework.TestSuite {
+	return &s3CSICredentialsSuite{
+		info: storageframework.TestSuiteInfo{
+			Name: "credentials",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (s *s3CSICredentialsSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo { return s.info }
+func (s *s3CSICredentialsSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+// getMountOptionsForNonRootUser returns standard mount options for non-root access
+func getMountOptionsForNonRootUser() []string {
+	return []string{
+		"allow-other",
+		fmt.Sprintf("uid=%d", DefaultNonRootUser),
+		fmt.Sprintf("gid=%d", DefaultNonRootGroup),
+	}
+}
+
+// CreateVolumeWithSecretReference creates a volume with authentication settings and S3 bucket configuration
+func CreateVolumeWithSecretReference(
+	ctx context.Context,
+	config *storageframework.PerTestConfig,
+	pattern storageframework.TestPattern,
+	secretName string,
+	namespace string,
+	bucketName string,
+) *storageframework.VolumeResource {
+
+	f := config.Framework
+	r := storageframework.VolumeResource{Config: config, Pattern: pattern}
+
+	pDriver := config.Driver.(storageframework.PreprovisionedPVTestDriver)
+	r.Volume = pDriver.CreateVolume(ctx, config, storageframework.PreprovisionedPV)
+	pvSource, nodeAffinity := pDriver.GetPersistentVolumeSource(false, "", r.Volume)
+
+	pvName := fmt.Sprintf("s3-e2e-pv-%s", uuid.NewString())
+	pvcName := fmt.Sprintf("s3-e2e-pvc-%s", uuid.NewString())
+
+	// Use standard mount options for non-root access
+	mountOptions := getMountOptionsForNonRootUser()
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: pvName},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: *pvSource,
+			StorageClassName:       "",
+			NodeAffinity:           nodeAffinity,
+			MountOptions:           mountOptions,
+			AccessModes:            []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			Capacity:               v1.ResourceList{v1.ResourceStorage: resource.MustParse("1200Gi")},
+			ClaimRef: &v1.ObjectReference{
+				Name:      pvcName,
+				Namespace: namespace,
+			},
+		},
+	}
+
+	// Set authentication attributes
+	pv.Spec.CSI.VolumeAttributes = map[string]string{
+		"bucketName":           bucketName,
+		"authenticationSource": "secret",
+	}
+	pv.Spec.CSI.NodePublishSecretRef = &v1.SecretReference{
+		Name:      secretName,
+		Namespace: namespace,
+	}
+
+	// Create the PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: ptr.To(""),
+			VolumeName:       pvName,
+			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1200Gi")},
+			},
+		},
+	}
+
+	// Create PV and PVC
+	framework.Logf("Creating PV %s and PVC %s with bucket %s", pvName, pvcName, bucketName)
+	var err error
+	r.Pv, err = f.ClientSet.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+	r.Pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+
+	// wait until both PV and PVC are Bound
+	err = e2epv.WaitOnPVandPVC(ctx, f.ClientSet, f.Timeouts, namespace, r.Pv, r.Pvc)
+	framework.ExpectNoError(err)
+
+	return &r
+}
+
+func createVolumeWithSecretReference(
+	ctx context.Context,
+	config *storageframework.PerTestConfig,
+	pattern storageframework.TestPattern,
+	secretName string,
+	namespace string,
+	bucketName string,
+) *storageframework.VolumeResource {
+	return CreateVolumeWithSecretReference(ctx, config, pattern, secretName, namespace, bucketName)
+}
+
+func (s *s3CSICredentialsSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+
+	f := framework.NewFrameworkWithCustomTimeouts("credentials", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelRestricted
+
+	ginkgo.It("mounts with default driver credentials and sees Bart‑owned objects", func(ctx context.Context) {
+		type TestResourceRegistry struct {
+			resources []*storageframework.VolumeResource // tracks resources for cleanup
+			config    *storageframework.PerTestConfig    // storage framework configuration
+		}
+		var (
+			testRegistry TestResourceRegistry
+		)
+		cleanup := func(ctx context.Context) {
+			var errs []error
+			for _, resource := range testRegistry.resources {
+				errs = append(errs, resource.CleanupResource(ctx))
+			}
+			framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+		}
+		testRegistry = TestResourceRegistry{}
+		testRegistry.config = driver.PrepareTest(ctx, f)
+		ginkgo.DeferCleanup(cleanup)
+		bartS3Client := s3client.New("", bartAK, bartSK)
+
+		// Use createVolumeResourceWithMountOptions from utils
+		resource := createVolumeResourceWithMountOptions(ctx, testRegistry.config, pattern, getMountOptionsForNonRootUser())
+		testRegistry.resources = append(testRegistry.resources, resource)
+
+		bucketName := resource.Pv.Spec.CSI.VolumeAttributes["bucketName"]
+
+		pod, err := CreatePodWithVolumeAndSecurity(ctx, f, resource.Pvc, "", DefaultNonRootUser, DefaultNonRootGroup)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+
+		filePath := "/mnt/volume1/pod-write-default.txt"
+		WriteAndVerifyFile(f, pod, filePath, "hello default")
+
+		// List all objects in the bucket to verify the file exists
+		ginkgo.By("Listing all objects in the bucket to verify file exists")
+		framework.Logf("Bucket name: %s, Looking for object: pod-write-default.txt", bucketName)
+		_, err = bartS3Client.ListObjects(ctx, bucketName)
+		framework.ExpectNoError(err)
+
+		// Attempt to verify owner ID, but handle potential errors gracefully
+		ginkgo.By("Attempting to verify object has Bart's canonical ID (if owner info available)")
+		ownerID, err := bartS3Client.GetObjectOwnerID(ctx, bucketName, "pod-write-default.txt")
+		framework.ExpectNoError(err)
+		gomega.Expect(ownerID).To(gomega.Equal(bartCID),
+			"Object owner ID should match Bart's canonical ID. Default credentials might be incorrect.")
+	})
+
+	ginkgo.It("mounts with Secret credentials and sees Lisa‑owned objects", func(ctx context.Context) {
+		// Create a bucket with Lisa's credentials
+		lisaS3Client := s3client.New("", lisaAK, lisaSK)
+		bucketName, deleteBucket := lisaS3Client.CreateBucket(ctx)
+		ginkgo.DeferCleanup(deleteBucket)
+
+		// Make a Secret with Lisa's credentials in test namespace
+		secretName, err := CreateCredentialSecret(ctx, f, "lisa-cred", lisaAK, lisaSK)
+		framework.ExpectNoError(err)
+
+		// Build PV/PVC that use the Secret (authSource=secret)
+		cfg := driver.PrepareTest(ctx, f)
+
+		volumeResource := createVolumeWithSecretReference(
+			ctx,
+			cfg,
+			pattern,
+			secretName,
+			f.Namespace.Name,
+			bucketName,
+		)
+
+		// Create a non-root pod with the volume
+		ginkgo.By("Creating pod with a volume using secret credentials")
+		pod, err := CreatePodWithVolumeAndSecurity(ctx, f, volumeResource.Pvc, "", DefaultNonRootUser, DefaultNonRootGroup)
+		framework.ExpectNoError(err)
+
+		// Write a test file
+		filePath := "/mnt/volume1/pod-write.txt"
+		WriteAndVerifyFile(f, pod, filePath, "hello lisa")
+
+		// Verify Lisa's canonical ID as owner via ListObjectsV2 FetchOwner
+		ginkgo.By("Verifying object has Lisa's canonical ID")
+		ownerID, err := lisaS3Client.GetObjectOwnerID(ctx, bucketName, "pod-write.txt")
+		framework.ExpectNoError(err)
+		gomega.Expect(ownerID).To(gomega.Equal(lisaCID),
+			"object owner ID should match Lisa's canonical ID – Secret creds were not applied")
+	})
+
+	ginkgo.It("fails to mount with 'access key Id does not exist' error when using invalid credentials", func(ctx context.Context) {
+		RunNegativeCredentialsTest(
+			ctx,
+			f,
+			driver,
+			pattern,
+			NegativeCredentialTestSpec{
+				// Use Lisa to create the bucket
+				BucketOwnerAK: lisaAK,
+				BucketOwnerSK: lisaSK,
+				// Use invalid credentials in the pod
+				PodAK:           "invalid" + uuid.NewString()[:8],
+				PodSK:           "veryInvalidKey" + uuid.NewString()[:8],
+				ErrorPattern:    "Forbidden: The AWS access key Id you provided does not exist in our records",
+				TestDescription: "non-existent access key causing authentication failure",
+				CustomPodName:   "test-invalid-key-" + uuid.NewString()[:8],
+			},
+		)
+	})
+
+	ginkgo.It("fails to mount with 'Access Denied Error: Failed to create mount process' error when using valid credentials without permissions", func(ctx context.Context) {
+		RunNegativeCredentialsTest(
+			ctx,
+			f,
+			driver,
+			pattern,
+			NegativeCredentialTestSpec{
+				// Use Bart to create the bucket
+				BucketOwnerAK: bartAK,
+				BucketOwnerSK: bartSK,
+				// Use Lisa's credentials to try to access Bart's bucket
+				PodAK:           lisaAK,
+				PodSK:           lisaSK,
+				ErrorPattern:    "Access Denied Error: Failed to create mount process",
+				TestDescription: "valid credentials without permission to access bucket",
+				CustomPodName:   "test-access-denied-" + uuid.NewString()[:8],
+			},
+		)
+	})
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -74,6 +74,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	customsuites.InitS3CSICacheTestSuite,
 	customsuites.InitS3FilePermissionsTestSuite,
 	customsuites.InitS3DirectoryPermissionsTestSuite,
+	customsuites.InitS3CredentialsTestSuite,
 }
 
 // initS3Driver initializes and returns an S3 CSI driver implementation for E2E testing.

--- a/tests/e2e/testdriver.go
+++ b/tests/e2e/testdriver.go
@@ -35,7 +35,7 @@ var _ framework.PreprovisionedPVTestDriver = &s3Driver{}
 
 func initS3Driver() *s3Driver {
 	return &s3Driver{
-		client: s3client.New(),
+		client: s3client.New("", "", ""),
 		driverInfo: framework.DriverInfo{
 			Name:        "s3.csi.scality.com",
 			MaxFileSize: framework.FileSizeLarge,


### PR DESCRIPTION
Key changes include the addition of a new credentials test suite, updates to credential validation rules, and improvements to the S3 client and utility functions. It also changes the go test command to ginkgo so we can increase the timeout.