### PR TITLE
S3CSI-73:  Fix a flaky test and Parallelize e2e tests + update runner cores

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -24,7 +24,7 @@ jobs:
 
   e2e-tests:
     name: Execute E2E Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-16core
     needs: dev-image
     steps:
       - name: Check out repository

--- a/tests/e2e/scripts/modules/test.sh
+++ b/tests/e2e/scripts/modules/test.sh
@@ -53,7 +53,7 @@ run_go_tests() {
   # Convert go test flags to ginkgo flags: -v ./... becomes -v ./..., -ginkgo.v becomes -v
   # Pass credential flags after --
   # Add 15m timeout
-  local ginkgo_test_cmd="KUBECONFIG=${KUBECONFIG} ginkgo -timeout=15m -v ./... -- --access-key-id=${access_key_id} --secret-access-key=${secret_access_key} --s3-endpoint-url=${s3_endpoint_url}"
+  local ginkgo_test_cmd="KUBECONFIG=${KUBECONFIG} ginkgo --procs=12 -timeout=15m -v ./... -- --access-key-id=${access_key_id} --secret-access-key=${secret_access_key} --s3-endpoint-url=${s3_endpoint_url}"
 
   # Add JUnit report if specified
   if [ -n "$junit_report" ]; then
@@ -88,7 +88,7 @@ run_go_tests() {
 
     # Use the correct format for Ginkgo JUnit report (-junit-report=...)
     # Keep -v flag for verbosity and add 15m timeout
-    ginkgo_test_cmd="KUBECONFIG=${KUBECONFIG} ginkgo -timeout=15m -v -junit-report='$junit_absolute_path' ./... -- --access-key-id=${access_key_id} --secret-access-key=${secret_access_key} --s3-endpoint-url=${s3_endpoint_url}"
+    ginkgo_test_cmd="KUBECONFIG=${KUBECONFIG} ginkgo --procs=12 -timeout=15m -v -junit-report='$junit_absolute_path' ./... -- --access-key-id=${access_key_id} --secret-access-key=${secret_access_key} --s3-endpoint-url=${s3_endpoint_url}"
     log "Final JUnit report path: $junit_absolute_path"
   fi
 


### PR DESCRIPTION
- There was a flaky unit test that was not parallel run proof, and we ran unit tests in parallel. This one was flaky.
- Second fix is to make E2E tests run in parallel + change running to 16 cores. E2E tests take ~3 mins instead of ~14 mins. We need this parallelization for a faster feedback loop, as we will add more tests.



