### PR TITLE
S3CSI-74: Add Sample S3 Endpoint URL to Default Values

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
@@ -119,7 +119,7 @@ spec:
               value: {{ .Values.mountpointPod.namespace }}
             {{- end }}
             - name: AWS_ENDPOINT_URL
-              value: {{ required "S3 endpoint URL (.Values.node.s3EndpointUrl) must be provided for the CSI driver to function" .Values.node.s3EndpointUrl }}
+              value: {{ .Values.node.s3EndpointUrl }}
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -47,8 +47,9 @@ node:
                   - hybrid
   podInfoOnMountCompat:
     enable: false
-  # AWS S3 endpoint URL to use for all volume mounts (REQUIRED)
-  s3EndpointUrl: ""
+  # S3 endpoint URL to use for all volume mounts (REQUIRED)
+  # This is a sample value, replace with your own S3 endpoint
+  s3EndpointUrl: "http://s3.example.com:8000"
 
 sidecars:
   nodeDriverRegistrar:


### PR DESCRIPTION
The Helm chart validation requires node.s3EndpointUrl to be provided, causing the following error during templating or CI:

```sh
Error: execution error at (scality-mountpoint-s3-csi-driver/templates/node.yaml:122:24): S3 endpoint URL (.Values.node.s3EndpointUrl) must be provided for the CSI driver to function
```

This breaks CI pipelines and makes it difficult for users to preview the templated resources without explicitly setting this value.
[Sample successful helm release from this branch](https://github.com/scality/mountpoint-s3-csi-driver/actions/runs/15037680110)
[Failed release example
](https://github.com/scality/mountpoint-s3-csi-driver/actions/runs/15037396563)

Note: This is a non-functional change that only improves release. The sample value is just a placeholder and must be overridden with actual values in production environments, we will have this in README once we are on docs stage.