### PR TITLE
S3CSI-69: Update supported K8s version to >=1.30.0-0

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scality-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Scality S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
 version: 0.1.0
-kubeVersion: ">=1.23.0-0"
+kubeVersion: ">=1.30.0-0"
 home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:
   - https://github.com/scality/mountpoint-s3-csi-driver


### PR DESCRIPTION
Updated the supported k8s version to 1.30.0-0 and above in the helm chart as thats what is needed by our customers. We are intentionally reducing the scope to make maintainability easier. We currently have no need for supporting older versions of k8s. This is a change in our supported versions and not a change in the minimum required version.