### PR TITLE
S3CSI-68: Move from AWS hosted to standard open source images and update/pin them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     patchelf --set-rpath '$ORIGIN' /mountpoint-s3/bin/mount-s3
 
 # Build driver. Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.24-bullseye as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24-bullseye as builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/scality/mountpoint-s3-csi-driver

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG MOUNTPOINT_VERSION=1.15.0
 # Building on Amazon Linux 2 because it has an old libc version. libfuse from the os
 # is being packaged up in the container and a newer version linking to a too new glibc
 # can cause portability issues
-FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as mp_builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS mp_builder
 ARG MOUNTPOINT_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
@@ -43,7 +43,7 @@ RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     patchelf --set-rpath '$ORIGIN' /mountpoint-s3/bin/mount-s3
 
 # Build driver. Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24-bullseye as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24-bullseye AS builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/scality/mountpoint-s3-csi-driver
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 
 # `eks-distro-minimal-base-csi` includes `libfuse` and mount utils such as `umount`.
 # We need to make sure to use same Amazon Linux version here and while producing Mountpoint to not have glibc compatibility issues.
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:2025-04-17-1744916492.2 AS linux-amazon
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:2025-04-17-1744916492.2 AS linux-amazon
 ARG MOUNTPOINT_VERSION
 ENV MOUNTPOINT_VERSION=${MOUNTPOINT_VERSION}
 ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 
 # `eks-distro-minimal-base-csi` includes `libfuse` and mount utils such as `umount`.
 # We need to make sure to use same Amazon Linux version here and while producing Mountpoint to not have glibc compatibility issues.
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:latest AS linux-amazon
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:2025-04-17-1744916492.2 AS linux-amazon
 ARG MOUNTPOINT_VERSION
 ENV MOUNTPOINT_VERSION=${MOUNTPOINT_VERSION}
 ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -12,7 +12,7 @@ ARG MOUNTPOINT_BUILD_ARGS="" # custom build arguments
 #
 # Build Mountpoint
 #
-FROM --platform=$TARGETPLATFORM amazonlinux:2023 as mp_builder
+FROM amazonlinux:2023 AS mp_builder
 ARG MOUNTPOINT_REPOSITORY
 ARG MOUNTPOINT_BRANCH
 ARG MOUNTPOINT_BUILD_ARGS
@@ -46,7 +46,7 @@ RUN cd mountpoint-s3 && \
 #
 
 # Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24-bullseye as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24-bullseye AS builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/scality/mountpoint-s3-csi-driver
@@ -60,7 +60,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 
 # `eks-distro-minimal-base-csi` includes `libfuse` and mount utils such as `umount`.
 # We need to make sure to use same Amazon Linux version here and while building Mountpoint to not have glibc compatibility issues.
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:latest-al23 AS linux-amazon
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:latest-al23 AS linux-amazon
 ARG MOUNTPOINT_VERSION
 ENV MOUNTPOINT_VERSION=${MOUNTPOINT_VERSION}
 ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -46,7 +46,7 @@ RUN cd mountpoint-s3 && \
 #
 
 # Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.24-bullseye as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24-bullseye as builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/scality/mountpoint-s3-csi-driver

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -41,8 +41,8 @@ node:
 sidecars:
   nodeDriverRegistrar:
     image:
-      repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.10.0-eks-1-29-7
+      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+      tag: v2.13.0
       pullPolicy: IfNotPresent
     env:
       - name: KUBE_NODE_NAME

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -57,8 +57,8 @@ sidecars:
     resources: {}
   livenessProbe:
     image:
-      repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.12.0-eks-1-29-7
+      repository: registry.k8s.io/sig-storage/livenessprobe
+      tag: v2.15.0
       pullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /csi


### PR DESCRIPTION
I have separated the image updates into separate commits, but the PR can be reviewed as a whole.
The reason for separate commits is that they are unique logical changes.