### PR TITLE
S3CSI-29: Add tests suite for prefix, region and read-only mountoptions

### DIFF
--- a/tests/e2e/customsuites/mountoptions.go
+++ b/tests/e2e/customsuites/mountoptions.go
@@ -17,6 +17,8 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 )
 
 // s3CSIMountOptionsTestSuite implements the Kubernetes storage framework TestSuite interface.
@@ -436,5 +438,302 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 		// Verify we can read what we wrote
 		ginkgo.By("Verifying read from the volume")
 		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("cat %s | grep -q '%s'", fileInVol, testContent))
+	})
+
+	// This test verifies that when a volume is mounted with the --prefix option,
+	// but no files are created, the prefix doesn't exist in the bucket.
+	//
+	// Test scenario:
+	//
+	//      [Pod]
+	//        |
+	//        ↓
+	//   [S3 Volume with --prefix=test-prefix/]
+	//        |
+	//        ↓
+	//    [No prefix created]
+	//
+	// The test specifically checks:
+	// 1. The prefix doesn't exist in the bucket before mounting
+	// 2. The volume with prefix option can be successfully mounted and accessed
+	// 3. The prefix still doesn't exist in the bucket after mounting
+	//
+	// This validates that the S3 CSI driver doesn't implicitly create the prefix
+	// in the S3 bucket just by mounting with the prefix option.
+	ginkgo.It("should not create prefix in bucket when no files are created", func(ctx context.Context) {
+		// We need to access the S3 client directly to verify objects
+		s3Client := s3client.New("", "", "") // Default credentials/region
+		var err error
+
+		// Create volume with standard non-root options plus prefix option
+		prefix := "empty-prefix/"
+		resource := BuildVolumeWithOptions(
+			ctx,
+			l.config,
+			pattern,
+			DefaultNonRootUser,
+			DefaultNonRootGroup,
+			"",                               // No specific file mode
+			fmt.Sprintf("prefix=%s", prefix), // Add the prefix option
+		)
+		l.resources = append(l.resources, resource)
+
+		// Extract the bucket name from the volume for verification
+		bucketName := GetBucketNameFromVolumeResource(resource)
+		if bucketName == "" {
+			framework.Failf("Failed to extract bucket name from volume resource")
+		}
+
+		// List all objects in the bucket to verify the prefix doesn't exist BEFORE mounting
+		ginkgo.By("Verifying prefix doesn't exist in bucket before mounting")
+		rootListOutputBefore, err := s3Client.ListObjects(ctx, bucketName)
+		framework.ExpectNoError(err, "Failed to list objects in bucket before mounting")
+
+		// Check if any objects with the prefix exist before mounting
+		prefixExistsBefore := false
+		for _, obj := range rootListOutputBefore.Contents {
+			if strings.HasPrefix(*obj.Key, prefix) {
+				prefixExistsBefore = true
+				break
+			}
+		}
+
+		if prefixExistsBefore {
+			framework.Failf("Prefix %s already exists in bucket %s before mounting", prefix, bucketName)
+		} else {
+			framework.Logf("Verified prefix %s does not exist in bucket %s before mounting", prefix, bucketName)
+		}
+
+		// Create pod with the prefixed volume
+		ginkgo.By("Creating pod with a volume using prefix option")
+		pod := MakeNonRootPodWithVolume(f.Namespace.Name, []*v1.PersistentVolumeClaim{resource.Pvc}, "")
+		pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+
+		// Verify the mount point exists and is accessible
+		volPath := "/mnt/volume1"
+		ginkgo.By("Verifying volume is mounted and accessible")
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("ls -la %s", volPath))
+
+		// List all objects in the bucket to verify the prefix doesn't exist AFTER mounting
+		ginkgo.By("Verifying prefix doesn't exist in bucket after mounting")
+		rootListOutputAfter, err := s3Client.ListObjects(ctx, bucketName)
+		framework.ExpectNoError(err, "Failed to list objects in bucket after mounting")
+
+		// Check if any objects with the prefix exist after mounting
+		prefixExistsAfter := false
+		for _, obj := range rootListOutputAfter.Contents {
+			if strings.HasPrefix(*obj.Key, prefix) {
+				prefixExistsAfter = true
+				break
+			}
+		}
+
+		if prefixExistsAfter {
+			framework.Failf("Prefix %s was created in bucket %s just by mounting", prefix, bucketName)
+		} else {
+			framework.Logf("Verified prefix %s was not created in bucket %s just by mounting", prefix, bucketName)
+		}
+	})
+
+	// This test verifies that the --prefix mount option correctly isolates
+	// objects within a specific prefix in the S3 bucket.
+	//
+	// Test scenario:
+	//
+	//      [Pod]
+	//        |
+	//        ↓
+	//   [S3 Volume with --prefix=test-prefix/]
+	//        |
+	//        ↓
+	//    [Files stored under test-prefix/ in S3]
+	//
+	// Expected results:
+	// - Files created in the mounted volume are stored under the specified prefix in S3
+	// - The files can be accessed through the mounted path without the prefix in the path
+	// - No objects are created at the root of the bucket (outside the prefix)
+	//
+	// This validates that the S3 CSI driver correctly handles the --prefix mount option
+	// to properly isolate multiple users or applications within a single bucket.
+	ginkgo.It("should store files under specified prefix when using --prefix option", func(ctx context.Context) {
+		// We need to access the S3 client directly to verify objects
+		s3Client := s3client.New("", "", "") // Default credentials/region
+
+		// Create volume with standard non-root options plus prefix option
+		prefix := "test-prefix/"
+		resource := BuildVolumeWithOptions(
+			ctx,
+			l.config,
+			pattern,
+			DefaultNonRootUser,
+			DefaultNonRootGroup,
+			"",                               // No specific file mode
+			fmt.Sprintf("prefix=%s", prefix), // Add the prefix option
+		)
+		l.resources = append(l.resources, resource)
+
+		// Extract the bucket name from the volume for verification
+		bucketName := GetBucketNameFromVolumeResource(resource)
+		if bucketName == "" {
+			framework.Failf("Failed to extract bucket name from volume resource")
+		}
+
+		// Create pod with the prefixed volume
+		ginkgo.By("Creating pod with a volume using prefix option")
+		pod := MakeNonRootPodWithVolume(f.Namespace.Name, []*v1.PersistentVolumeClaim{resource.Pvc}, "")
+		var err error
+		pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+
+		volPath := "/mnt/volume1"
+		testFileName := "prefix-test.txt"
+		fileInVol := fmt.Sprintf("%s/%s", volPath, testFileName)
+		testContent := "Testing prefix mount option"
+
+		// Write a file to the volume
+		ginkgo.By("Writing a file to the volume")
+		WriteAndVerifyFile(f, pod, fileInVol, testContent)
+
+		// Verify file can be read from the pod
+		ginkgo.By("Verifying file can be read from pod")
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("cat %s | grep -q '%s'", fileInVol, testContent))
+
+		// List objects in the bucket to verify the object was created under the prefix
+		ginkgo.By(fmt.Sprintf("Verifying object exists under prefix %s in bucket", prefix))
+
+		// Use s3client's VerifyObjectsExistInS3 method instead of manual listing and checking
+		err = s3Client.VerifyObjectsExistInS3(ctx, bucketName, prefix, []string{testFileName})
+		framework.ExpectNoError(err, "Failed to verify object exists under prefix %s", prefix)
+		framework.Logf("Successfully found object %s under prefix %s in bucket %s", testFileName, prefix, bucketName)
+
+		// List objects in the bucket without the prefix to verify no objects exist at the root
+		ginkgo.By("Verifying no objects exist at the root of the bucket")
+		rootListOutput, err := s3Client.ListObjects(ctx, bucketName)
+		framework.ExpectNoError(err, "Failed to list objects in bucket")
+
+		// Verify no objects exist at the root (that don't have the prefix)
+		for _, obj := range rootListOutput.Contents {
+			if !strings.HasPrefix(*obj.Key, prefix) {
+				framework.Failf("Found unexpected object %s at root of bucket", *obj.Key)
+			}
+		}
+		framework.Logf("No unexpected objects found at root of bucket - all objects have the prefix %s", prefix)
+	})
+
+	// This test verifies that when objects are created directly in S3 under a prefix,
+	// they are visible when mounting with that prefix, and new objects created through
+	// the mount are also visible when listing the prefix directly from S3.
+	//
+	// Test scenario:
+	//
+	//      [Direct S3 API]  →  [Objects under prefix]  ←  [Mounted Volume]
+	//
+	// The test specifically:
+	// 1. Creates objects directly in S3 under a specific prefix
+	// 2. Mounts a volume with that same prefix
+	// 3. Verifies the pre-created objects are visible through the mount
+	// 4. Creates new objects through the mount
+	// 5. Verifies the new objects are visible when listing the prefix via S3 API
+	//
+	// This validates that the prefix mount option works bidirectionally with objects
+	// created both through the S3 API and through the mounted volume.
+	ginkgo.It("should see objects created directly in S3 under prefix and make new objects visible to S3", func(ctx context.Context) {
+		// We need to access the S3 client directly to create and list objects
+		s3Client := s3client.New(s3client.DefaultRegion, "", "") // Using DefaultRegion from s3client
+		var err error
+
+		// Create volume with standard non-root options plus prefix option
+		prefix := "test-both-directions/"
+		resource := BuildVolumeWithOptions(
+			ctx,
+			l.config,
+			pattern,
+			DefaultNonRootUser,
+			DefaultNonRootGroup,
+			"",                               // No specific file mode
+			fmt.Sprintf("prefix=%s", prefix), // Add the prefix option
+		)
+		l.resources = append(l.resources, resource)
+
+		// Extract the bucket name from the volume for direct S3 operations
+		bucketName := GetBucketNameFromVolumeResource(resource)
+		if bucketName == "" {
+			framework.Failf("Failed to extract bucket name from volume resource")
+		}
+
+		directFileKeys := []string{
+			"direct-file1.txt",
+			"direct-file2.txt",
+			"subdir/direct-file3.txt",
+		}
+
+		// Create objects directly in S3 under the prefix
+		ginkgo.By(fmt.Sprintf("Creating objects directly in S3 under prefix %s", prefix))
+		err = s3Client.CreateObjectsInS3(ctx, bucketName, prefix, directFileKeys)
+		framework.ExpectNoError(err, "Failed to create objects directly in S3")
+
+		// Verify objects exist in S3
+		ginkgo.By(fmt.Sprintf("Verifying objects exist in S3 under prefix %s", prefix))
+		err = s3Client.VerifyObjectsExistInS3(ctx, bucketName, prefix, directFileKeys)
+		framework.ExpectNoError(err, "Failed to verify objects exist in S3")
+
+		// Create pod with the prefixed volume
+		ginkgo.By("Creating pod with a volume that uses the same prefix")
+		pod := MakeNonRootPodWithVolume(f.Namespace.Name, []*v1.PersistentVolumeClaim{resource.Pvc}, "")
+		pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+
+		// Verify the directly created files are visible through the mount
+		volPath := "/mnt/volume1"
+		ginkgo.By("Verifying directly created files are visible through the mount")
+
+		// Verify files exist in pod using our helper method
+		VerifyFilesExistInPod(f, pod, volPath, directFileKeys)
+
+		// Additional verification for subdirectory
+		subdirPath := fmt.Sprintf("%s/subdir", volPath)
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("test -d %s", subdirPath))
+
+		// Define mount-created file paths (these will be created through the mount)
+		mountCreatedFiles := []string{
+			"mount-file1.txt",
+			"mount-file2.txt",
+			"subdir/mount-file3.txt",
+		}
+
+		// Create files in pod using our helper method
+		CreateFilesInPod(f, pod, volPath, mountCreatedFiles)
+
+		// Verify new files are visible via S3 API with the prefix
+		ginkgo.By("Verifying new files are visible via S3 API with the prefix")
+
+		// Verify objects exist in S3
+		err = s3Client.VerifyObjectsExistInS3(ctx, bucketName, prefix, mountCreatedFiles)
+		framework.ExpectNoError(err, "Failed to verify mount-created objects exist in S3")
+
+		// Additional verification that all objects are present (both direct and mount-created)
+		allFiles := append([]string{}, directFileKeys...)
+		allFiles = append(allFiles, mountCreatedFiles...)
+
+		prefixListAfter, err := s3Client.ListObjectsWithPrefix(ctx, bucketName, prefix)
+		framework.ExpectNoError(err, "Failed to list objects with prefix after creating files through mount")
+
+		// We should have all files (direct + mount-created)
+		if len(prefixListAfter.Contents) < len(allFiles) {
+			framework.Failf("Expected at least %d objects after creating files through mount, but found %d",
+				len(allFiles), len(prefixListAfter.Contents))
+		}
+
+		framework.Logf("Successfully verified bidirectional visibility between S3 API and mounted volume with prefix")
 	})
 }


### PR DESCRIPTION
Added tests for volume level options for specifying `--region` (overrides driver level region), `--prefix` (mounts bucket using a specific prefix), and `--read-only` (for read only filesystem)

The test cases added are either important for us or we have changed the related options behaviour so we need to test.
The rest of the scenarios are testing in the [upstream mountpoint-s3](https://github.com/awslabs/mountpoint-s3)