### PR TITLE
S3CSI-17: setup GitHub pages for documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "scality/object"
+    commit-message:
+      prefix: "pip"
+      include: scope
+    labels:
+      - "dependencies"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,51 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Scality Mountpoint S3 CSI Driver
+
+(sample for MKdocs integration - to be updated)
+
+The Scality Mountpoint S3 CSI Driver implements the [Container Storage Interface](https://github.com/container-storage-interface/spec/blob/master/spec.md) for S3 object storage, allowing Kubernetes workloads to mount S3 buckets as persistent volumes.
+
+## Overview
+
+This driver leverages [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3), a high-performance open-source file client for mounting an S3 bucket as a local file system, enabling the following capabilities:
+
+- Mount S3 buckets as Kubernetes PersistentVolumes
+- Support for dynamic
+- Mount option configuration (read-only, prefix, etc.)
+- S3 object API integration
+
+## Installation
+
+<!-- For detailed installation instructions, see the [deployment guide](./deployment.md). -->
+
+```bash
+# Quick installation using Helm
+helm repo add scality https://scality.github.io/mountpoint-s3-csi-driver/charts
+helm install mountpoint-s3-csi-driver scality/scality-mountpoint-s3-csi-driver
+```
+
+## Usage
+
+Create a StorageClass, PersistentVolumeClaim, and Pod with the CSI driver:
+
+```yaml
+# Example StorageClass for dynamic provisioning
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: s3-storage
+provisioner: s3.csi.scality.com
+parameters:
+  # Add your parameters here
+```
+
+## Documentation
+
+<!-- - [Configuration Options](./configuration.md) -->
+<!-- - [Examples](./examples.md) -->
+<!-- - [Troubleshooting](./troubleshooting.md)  -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,44 @@
+site_name: "Scality S3 CSI Driver"
+site_url: https://scality.github.io/mountpoint-s3-csi-driver 
+repo_url: https://github.com/scality/mountpoint-s3-csi-driver
+edit_uri: edit/main/docs/            # ← branch that holds Markdown
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - search.suggest
+
+plugins:
+  - search
+  - mermaid2
+  - awesome-pages
+  - enumerate-headings:
+      toc_depth: 3
+
+markdown_extensions:
+  - admonition
+  - tables
+  - attr_list
+  - md_in_html
+  - meta
+  - toc:
+      toc_depth: 3
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
+
+nav:
+  - Home: README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs==1.6.1                            # core SSG
+mkdocs-material==9.6.14                  # theme
+mkdocs-mermaid2-plugin==1.2.1            # diagrams
+mkdocs-awesome-pages-plugin==2.10.1      # sidebar ordering
+mkdocs-enumerate-headings-plugin==0.6.2  # auto-number headings
+codespell==2.4.1                         # spelling linter


### PR DESCRIPTION
Set up Github pages for documentation, motivation: https://citadel.scality.net/

Note: Real documentation has not been published yet, this is just setup.
URL: https://scality.github.io/mountpoint-s3-csi-driver/