### PR TITLE
S3CSI-40: Add matrix for E2E tests for RING S3 9.4 & 9.5

### DIFF
--- a/.github/scality-storage-deployment/cloudserver-config.json
+++ b/.github/scality-storage-deployment/cloudserver-config.json
@@ -45,5 +45,24 @@
         "viaProxy": false,
         "trustedProxyCIDRs": [],
         "extractClientIPFromHeader": ""
+    },
+    "metadataClient": {
+        "host": "127.0.0.1",
+        "port": 9990
+    },
+    "dataClient": {
+        "host": "127.0.0.1",
+        "port": 9991
+    },
+    "metadataDaemon": {
+        "bindAddress": "127.0.0.1",
+        "port": 9990
+    },
+    "dataDaemon": {
+        "bindAddress": "127.0.0.1",
+        "port": 9991
+    },
+    "bucketd": {
+        "bootstrap": ["localhost:9000"]
     }
 }

--- a/.github/scality-storage-deployment/docker-compose.yml
+++ b/.github/scality-storage-deployment/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     network_mode: host
     environment:
       S3_CONFIG_FILE: /conf/config.json
-    command: /bin/sh -c "yarn run mem_backend > /logs/s3/s3.log 2>&1"
+      S3VAULT: mem
+    command: /bin/sh -c "yarn start > /logs/s3/s3.log 2>&1"
     volumes:
       - ./cloudserver-config.json:/conf/config.json:ro
       - ./logs/s3:/logs/s3

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -61,11 +61,24 @@ jobs:
             CSI_IMAGE_REPOSITORY=ghcr.io/${{ github.repository }} \
             ADDITIONAL_ARGS="--junit-report=./test-results/e2e-tests-results.xml"
 
+      - name: Copy S3 logs to artifacts directory
+        if: always()
+        run: |
+          mkdir -p artifacts/logs/s3
+          cp -r .github/scality-storage-deployment/logs/s3/* artifacts/logs/s3/ 2>/dev/null || true
+
+      - name: Upload S3 logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-tests-${{ matrix.ring_version }}
+          path: artifacts
+
       - name: Upload test results to Codecov
         if: ${{ always() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./tests/e2e/test-results/e2e-tests-results.xml
-          flags: e2e_tests,cloudserver_${{ matrix.cloudserver_version }}
+          flags: e2e_tests,cloudserver_${{ matrix.ring_version }}
           slug: scality/mountpoint-s3-csi-driver

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -6,7 +6,6 @@ on:
       - '**'
 
 env:
-  CLOUDSERVER_TAG: ${{ vars.CLOUDSERVER_TAG }}
   KUBECONFIG: "/home/runner/.kube/config"
 
 jobs:
@@ -23,9 +22,19 @@ jobs:
       tag: ${{ github.sha }}
 
   e2e-tests:
-    name: Execute E2E Tests
+    name: E2E tests with RING S3 v${{ matrix.ring_version }}
     runs-on: ubuntu-22.04-8core
     needs: dev-image
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ring_version: "9.4"
+            github_varirable_name: "CLOUDSERVER_RING_9_4"
+          - ring_version: "9.5"
+            github_varirable_name: "CLOUDSERVER_RING_9_5"
+    env:
+      CLOUDSERVER_TAG: ${{ vars[matrix.github_varirable_name] }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -58,5 +67,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./tests/e2e/test-results/e2e-tests-results.xml
-          flags: e2e_tests
+          flags: e2e_tests,cloudserver_${{ matrix.cloudserver_version }}
           slug: scality/mountpoint-s3-csi-driver

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -43,6 +43,9 @@ exclude = [
     "^https?://10\\.",
     "^https?://172\\.(1[6-9]|2[0-9]|3[0-1])\\.",
 
+    # Exclude Scality artifacts URL (requires authentication)
+    "^https?://artifacts\\.scality\\.net",
+
     # Exclude social media and platforms known to block link checkers
     "^https?://(www\\.)?(linkedin|twitter|x)\\.com",
     "^https?://(www\\.)?facebook\\.com",


### PR DESCRIPTION
We need to ensure the S3 CSI driver E2E tests are compatible with both 9.4 and 9.5 versions of RING, as per a product request. This PR satisfies the same.