### PR TITLE
Switch deprecated reviewers to CODEOWNERS for dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @scality/object

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "scality/object"
     commit-message:
       prefix: "pip"
       include: scope


### PR DESCRIPTION
Issue: S3CSI-76

Switch deprecated reviewers to CODEOWNERS for dependabot
[Reference](https://github.com/scality/devdocs/discussions/718)