### PR TITLE
S3CSI-79: Update Codecov & CI to ignore docs updates and remove codeowners

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,6 +1,9 @@
 name: E2E Integration Tests with RING S3
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,9 +1,15 @@
-name: E2E Tests
+name: E2E Integration Tests with RING S3
 
 on:
-  push:
+  pull_request:
     branches:
       - '**'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'mkdocs.yml'
+      - 'requirements.txt'  # MkDocs requirements
+      - 'NOTICE'
 
 env:
   KUBECONFIG: "/home/runner/.kube/config"
@@ -22,7 +28,7 @@ jobs:
       tag: ${{ github.sha }}
 
   e2e-tests:
-    name: E2E tests with RING S3 v${{ matrix.ring_version }}
+    name: v${{ matrix.ring_version }}
     runs-on: ubuntu-22.04-8core
     needs: dev-image
     strategy:

--- a/.github/workflows/linting-and-formatting.yaml
+++ b/.github/workflows/linting-and-formatting.yaml
@@ -1,18 +1,18 @@
-name: Code Validation
+name: Linting and Formatting
 
 on:
-  push:
+  pull_request:
     branches:
       - '**'
 
 jobs:
-  tests:
+  code-quality-checks:
     name: Run
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        test: [precommit, lint, unit-test, csi-compliance-test, controller-integration-test, validate-helm, check-licenses]
+        test: [precommit, lint]
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -22,9 +22,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: true
-
-    - name: Setup Helm
-      uses: azure/setup-helm@v4.3.0
 
     - name: Set up Python and install pre-commit (for precommit test)
       uses: actions/setup-python@v5
@@ -57,21 +54,3 @@ jobs:
       uses: golangci/golangci-lint-action@v8
       with:
         version: v2.1.6
-
-    - name: Upload unit test coverage to Codecov
-      if: matrix.test == 'unit-test'
-      continue-on-error: true
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        slug: scality/mountpoint-s3-csi-driver
-
-    - name: Upload controller test results to Codecov
-      if: matrix.test == 'controller-integration-test'
-      continue-on-error: true
-      uses: codecov/test-results-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./controller-integration-tests-results.xml
-        flags: controller_integration_tests
-        slug: scality/mountpoint-s3-csi-driver

--- a/.github/workflows/linting-and-formatting.yaml
+++ b/.github/workflows/linting-and-formatting.yaml
@@ -1,6 +1,9 @@
 name: Linting and Formatting
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests-and-compliance.yaml
+++ b/.github/workflows/tests-and-compliance.yaml
@@ -1,6 +1,9 @@
 name: Tests and Compliance
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests-and-compliance.yaml
+++ b/.github/workflows/tests-and-compliance.yaml
@@ -1,0 +1,53 @@
+name: Tests and Compliance
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+
+jobs:
+  code-quality-tests:
+    name: Run
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [unit-test, csi-compliance-test, controller-integration-test, validate-helm, check-licenses]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Setup Helm
+      uses: azure/setup-helm@v4.3.0
+
+    - name: Run ${{ matrix.test }}
+      run: make ${{ matrix.test }}
+
+    - name: Upload unit test coverage to Codecov
+      if: matrix.test == 'unit-test'
+      continue-on-error: true
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: scality/mountpoint-s3-csi-driver
+
+    - name: Upload controller test results to Codecov
+      if: matrix.test == 'controller-integration-test'
+      continue-on-error: true
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./controller-integration-tests-results.xml
+        flags: controller_integration_tests
+        slug: scality/mountpoint-s3-csi-driver

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This repository hosts the Container Storage Interface (CSI) driver enabling Kube
 
 Refer to the [official documentation site](https://scality.github.io/mountpoint-s3-csi-driver/) for detailed installation, usage, and features.
 
-[![Code Validation](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/code-validation.yaml/badge.svg?branch=main)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/code-validation.yaml)
-[![E2E Tests](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/e2e-tests.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/e2e-tests.yaml)
+[![Linting and Formatting](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/linting-and-formatting.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/linting-and-formatting.yaml)
+[![Tests and Compliance](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/tests-and-compliance.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/tests-and-compliance.yaml)
+[![E2E Integration Tests with RING S3](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/e2e-tests.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/e2e-tests.yaml)


### PR DESCRIPTION
- Do not run E2E tests for documentation updates
- Split code validation into 2 stages, tests will not be run for documentation updates
- Remove CodeOwners
- Update badges for README