### PR TITLE
S3CSI-80: Update release to remove changelog and add docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,9 @@ jobs:
           name: Release ${{ inputs.tag }}
           generate_release_notes: true
           body: |
-            Mountpoint for Scality S3 CSI Driver
+            ## Scality S3 CSI Driver
 
-            ## CHANGELOG
-            See [CHANGELOG](https://github.com/scality/mountpoint-s3-csi-driver/blob/main/CHANGELOG.md) for full list of changes
+            📚 **Documentation**: https://scality.github.io/mountpoint-s3-csi-driver/
+
+            ### 🔍 What's Changed
+            <!-- GitHub will auto-populate this section with commits and PRs -->


### PR DESCRIPTION
We are not adding assets as there are prerequisites for helm install, we want users to refer to docs.
We also rely on github changelog and will not maintain a changelog manually. 