### PR TITLE
S3CSI-88: Make documentation website body and headers/footers responsive and enhance UX

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -16,6 +16,18 @@
     word-break: break-word;
 }
 
+/* Remove the max-width constraint on the main content */
+
+.md-main__inner.md-grid {
+    max-width: initial;
+}
+
+/* Remove the max-width constraint on the header and footer */
+
+.md-grid {
+    max-width: initial;
+}
+
 /* Make all headings bold for better hierarchy */
 .md-typeset h1,
 .md-typeset h2,


### PR DESCRIPTION
Makes user facing documentation more responsive for all devices, gives more space for actual documentation than borders
Note to reviewers: I tried alot fo things to achieve this but [this](https://github.com/squidfunk/mkdocs-material/discussions/6404#discussioncomment-7695243) helped me eventually

Old documentation:
<img width="2032" alt="Screenshot 2025-06-07 at 21 01 16" src="https://github.com/user-attachments/assets/c393ca36-40d9-454b-95a5-4a61373986f2" />


New documentation responsiveness and utilizing full page
<img width="2032" alt="Screenshot 2025-06-07 at 21 28 54" src="https://github.com/user-attachments/assets/58eb96a7-8ee0-4fd7-8521-c365f792ac98" />

