### PR TITLE
S3CSI-91: update version to 1.0.0 and use ghcr images for k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=0.6.0
+VERSION=1.0.0
 
 # List of allowed licenses in the CSI Driver's dependencies.
 # See https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28 for list of canonical names for licenses.

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: ghcr.io/scality/mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.6.0"
+  tag: "1.0.0"
 
 node:
   kubeletPath: /var/lib/kubelet
@@ -44,7 +44,7 @@ node:
 sidecars:
   nodeDriverRegistrar:
     image:
-      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+      repository: ghcr.io/scality/mountpoint-s3-csi-driver/csi-node-driver-registrar
       tag: v2.14.0
       pullPolicy: IfNotPresent
     env:
@@ -60,7 +60,7 @@ sidecars:
     resources: {}
   livenessProbe:
     image:
-      repository: registry.k8s.io/sig-storage/livenessprobe
+      repository: ghcr.io/scality/mountpoint-s3-csi-driver/livenessprobe
       tag: v2.16.0
       pullPolicy: IfNotPresent
     volumeMounts:


### PR DESCRIPTION
Update CSI driver image to 1.0.0
Also updated k8s image registries to GHCR as they [advise](https://github.com/kubernetes/registry.k8s.io?tab=readme-ov-file#stability)
> we highly recommend [mirroring](https://github.com/kubernetes/registry.k8s.io/blob/main/docs/mirroring/README.md) images to a location you control instead.