### PR TITLE
S3CSI-91: Use GHCR for image registry instead of k8s registry

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -44,7 +44,7 @@ node:
 sidecars:
   nodeDriverRegistrar:
     image:
-      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+      repository: ghcr.io/scality/mountpoint-s3-csi-driver/csi-node-driver-registrar
       tag: v2.14.0
       pullPolicy: IfNotPresent
     env:
@@ -60,7 +60,7 @@ sidecars:
     resources: {}
   livenessProbe:
     image:
-      repository: registry.k8s.io/sig-storage/livenessprobe
+      repository: ghcr.io/scality/mountpoint-s3-csi-driver/livenessprobe
       tag: v2.16.0
       pullPolicy: IfNotPresent
     volumeMounts:


### PR DESCRIPTION
Updated k8s image registries to GHCR as they [advise](https://github.com/kubernetes/registry.k8s.io?tab=readme-ov-file#stability)
> we highly recommend [mirroring](https://github.com/kubernetes/registry.k8s.io/blob/main/docs/mirroring/README.md) images to a location you control instead.