### PR TITLE
S3CSI-92: Modify E2E workflow for plug and play in Integration repo

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,10 +62,10 @@ jobs:
       - name: Run Scality Tests
         run: |
           mkdir -p test-results
+          # Load credentials from the integration config
+          source tests/e2e/scripts/load-credentials.sh
           make e2e-all \
             S3_ENDPOINT_URL=http://${{ steps.get_ip.outputs.host_ip }}:8000 \
-            ACCESS_KEY_ID=accessKey1 \
-            SECRET_ACCESS_KEY=verySecretKey1 \
             CSI_IMAGE_TAG=${{ github.sha }} \
             CSI_IMAGE_REPOSITORY=ghcr.io/${{ github.repository }} \
             ADDITIONAL_ARGS="--junit-report=./test-results/e2e-tests-results.xml"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,99 +1,76 @@
 # E2E Tests
 
-This directory contains end-to-end (e2e) tests for the Scality S3 CSI Driver. These tests validate the driver's
-functionality in real Kubernetes environments by performing complete workflows including installation, volume
-operations, and cleanup.
+End-to-end tests for the Scality S3 CSI Driver that validate functionality in real Kubernetes environments.
 
-## Running Tests
-
-Basic test execution:
+## Quick Start
 
 ```bash
-make e2e
+# 1. Load credentials (from integration_config.json)
+source tests/e2e/scripts/load-credentials.sh
+
+# 2. Run tests
+make e2e-all S3_ENDPOINT_URL=https://your-s3-endpoint.com
 ```
 
-## Test Structure
+## Available Commands
 
-The tests are organized into several components:
+| Command | Description |
+|---------|-------------|
+| `make e2e-all` | Install driver + run all tests |
+| `make e2e` | Run tests on existing driver |
+| `make e2e-go` | Run only Go-based tests |
 
-- S3 bucket creation and cleanup operations
-- CSI driver installation and verification  
-- Pod mounting and data operations
-- Volume lifecycle management
-- Cleanup and resource removal
+## Configuration
 
-## Test Configuration
+### Required
 
-Tests can be configured using environment variables or Make parameters:
+- **S3_ENDPOINT_URL**: Your S3 endpoint URL
+- **Credentials**: Load from `integration_config.json` using the load-credentials script
 
-- `CSI_NAMESPACE`: Kubernetes namespace for the driver (default: `kube-system`)
-- `S3_ENDPOINT_URL`: S3 endpoint URL for testing
-- `ACCESS_KEY_ID`: S3 access key for authentication
-- `SECRET_ACCESS_KEY`: S3 secret key for authentication
+### Optional
 
-Example with custom configuration:
+- **KUBECONFIG**: Path to kubeconfig (default: `~/.kube/config`)
+- **CSI_NAMESPACE**: Kubernetes namespace (default: `kube-system`)
+
+## Examples
 
 ```bash
-make e2e \
-  CSI_NAMESPACE=test-namespace \
-  S3_ENDPOINT_URL=https://s3.example.com \
-  ACCESS_KEY_ID=test_key \
-  SECRET_ACCESS_KEY=test_secret
+# Basic usage (loads from default integration_config.json)
+source tests/e2e/scripts/load-credentials.sh
+make e2e-all S3_ENDPOINT_URL=http://10.200.4.125:8000
+
+# Using custom credentials file
+source tests/e2e/scripts/load-credentials.sh --config-file /path/to/my-credentials.json
+make e2e-all S3_ENDPOINT_URL=https://s3.example.com
+
+# With custom kubeconfig
+make e2e-all S3_ENDPOINT_URL=https://s3.example.com KUBECONFIG=/path/to/config
+
+# Run only Go tests
+make e2e-go S3_ENDPOINT_URL=https://s3.example.com
 ```
 
-## Test Suites
+## Credential Configuration
 
-### Basic E2E Tests
+The `load-credentials.sh` script reads S3 credentials from a JSON configuration file and exports them as environment variables.
 
-Standard test suite that validates:
+### Default Configuration
 
-- Driver installation
-- Volume mounting
-- File operations
-- Cleanup procedures
+By default, credentials are loaded from `tests/e2e/integration_config.json`:
 
-### Go Test Suite
+### Using Custom Configuration File
 
-More comprehensive tests written in Go that include:
+```bash
+# Load from custom file
+source tests/e2e/scripts/load-credentials.sh --config-file /path/to/my-config.json
 
-- Multiple volume scenarios
-- Error handling validation
-- Performance benchmarks
-- Edge case testing
-
-## Custom Test Suites
-
-The `customsuites/` directory contains specialized test configurations for specific scenarios and environments.
-See [Custom Test Suites](./customsuites/README.md) for detailed information.
+# Or set environment variable
+export CREDENTIALS_CONFIG_FILE="/path/to/my-config.json"
+source tests/e2e/scripts/load-credentials.sh
+```
 
 ## Troubleshooting
 
-Common test failures and solutions:
-
-### Authentication Errors
-
-- Verify S3 credentials are correct
-- Check endpoint URL accessibility
-- Ensure bucket permissions are adequate
-
-### Network Issues
-
-- Validate cluster connectivity to S3 endpoint
-- Check firewall and security group settings
-- Verify DNS resolution
-
-### Resource Conflicts
-
-- Ensure namespace is clean before testing
-- Check for existing CSI driver installations
-- Verify sufficient cluster resources
-
-## Test Artifacts
-
-Tests generate artifacts in the following locations:
-
-- Test logs: `./test-logs/`
-- Generated manifests: `./generated/`
-- Temporary files: `/tmp/e2e-tests/`
-
-For development and debugging purposes, artifacts are preserved after test completion unless explicitly cleaned up.
+- **Authentication errors**: Check credentials in `integration_config.json`
+- **Network issues**: Verify S3 endpoint is accessible
+- **KUBECONFIG errors**: Ensure kubectl can connect to your cluster

--- a/tests/e2e/customsuites/README.md
+++ b/tests/e2e/customsuites/README.md
@@ -101,13 +101,30 @@ go test -v ./... \
 
 ## Configuration
 
-Custom tests use the same configuration as the main E2E test suite but support additional S3-specific parameters:
+### Credential Management
+
+Custom tests use the same credential loading system as the main E2E test suite. Load credentials before running tests:
+
+```bash
+# Load credentials from default config file
+source ../scripts/load-credentials.sh
+
+# Then run custom tests
+go test -v ./...
+```
+
+The credential loading script exports environment variables that the tests automatically use:
+
+- `ACCOUNT1_ACCESS_KEY`, `ACCOUNT1_SECRET_KEY`, `ACCOUNT1_CANONICAL_ID`
+- `ACCOUNT2_ACCESS_KEY`, `ACCOUNT2_SECRET_KEY`, `ACCOUNT2_CANONICAL_ID`
 
 ### Standard Parameters
 
+Custom tests support additional S3-specific parameters:
+
 - `--s3-endpoint-url`: S3 endpoint URL (required)
-- `--access-key-id`: S3 access key (required)  
-- `--secret-access-key`: S3 secret key (required)
+- `--access-key-id`: S3 access key (if not using credential loading)  
+- `--secret-access-key`: S3 secret key (if not using credential loading)
 
 ### Custom Parameters
 
@@ -176,13 +193,16 @@ Custom tests are integrated into the CI pipeline:
 
 ```yaml
 # Example CI configuration  
+- name: Load Test Credentials
+  run: |
+    cd tests/e2e/scripts
+    source ./load-credentials.sh
+
 - name: Run Custom Test Suites
   run: |
     cd tests/e2e/customsuites
     go test -v ./... \
       --s3-endpoint-url=${{ secrets.S3_ENDPOINT }} \
-      --access-key-id=${{ secrets.ACCESS_KEY_ID }} \
-      --secret-access-key=${{ secrets.SECRET_ACCESS_KEY }} \
       --cleanup-policy=always
 ```
 

--- a/tests/e2e/customsuites/util.go
+++ b/tests/e2e/customsuites/util.go
@@ -38,6 +38,18 @@ const (
 )
 
 /*──────────────────────────────
+  Environment variable helpers
+  ──────────────────────────────*/
+
+// GetEnv retrieves an environment variable value or returns a fallback
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+/*──────────────────────────────
   Batched creation primitives
   ──────────────────────────────*/
 

--- a/tests/e2e/integration_config.json
+++ b/tests/e2e/integration_config.json
@@ -1,0 +1,24 @@
+{
+    "credentials": {
+        "account": {
+            "account1": {
+                "username": "account1",
+                "email": "sampleaccount1@sampling.com",
+                "id": "294419410754",
+                "canonicalId": "4fc0bf6eb804bb09e64a820096436e00ea334e6497c245a2cc536c66426d8253",
+                "arn": "arn:aws:iam::294419410754:/account1/",
+                "accessKey": "VC04IZ5ELSLI5CF1OE5E",
+                "secretKey": "08tPoZodjaVMVB/ecX8kV0eZexH2hCdxUid/Qfib"
+            },
+            "account2": {
+                "username": "account2",
+                "email": "account2@example.com",
+                "id": "649023639558",
+                "canonicalId": "51f281b3474231d197e22d3b2d14187c9472401dc1455ed6a1cab2b864912f67",
+                "arn": "arn:aws:iam::649023639558:/account2/",
+                "accessKey": "AD06TXLP6I8ZTGQGOIO6",
+                "secretKey": "i=CfpAKy0bLwSYUzAjg+7RmHMfw5i79UPgy95KDd"
+            }
+        }
+    }
+}

--- a/tests/e2e/integration_config.json
+++ b/tests/e2e/integration_config.json
@@ -2,22 +2,22 @@
     "credentials": {
         "account": {
             "account1": {
-                "username": "account1",
+                "username": "Bart",
                 "email": "sampleaccount1@sampling.com",
-                "id": "294419410754",
-                "canonicalId": "4fc0bf6eb804bb09e64a820096436e00ea334e6497c245a2cc536c66426d8253",
-                "arn": "arn:aws:iam::294419410754:/account1/",
-                "accessKey": "VC04IZ5ELSLI5CF1OE5E",
-                "secretKey": "08tPoZodjaVMVB/ecX8kV0eZexH2hCdxUid/Qfib"
+                "id": "123456789012",
+                "canonicalId": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be",
+                "arn": "arn:aws:iam::123456789012:root",
+                "accessKey": "accessKey1",
+                "secretKey": "verySecretKey1"
             },
             "account2": {
-                "username": "account2",
-                "email": "account2@example.com",
-                "id": "649023639558",
-                "canonicalId": "51f281b3474231d197e22d3b2d14187c9472401dc1455ed6a1cab2b864912f67",
-                "arn": "arn:aws:iam::649023639558:/account2/",
-                "accessKey": "AD06TXLP6I8ZTGQGOIO6",
-                "secretKey": "i=CfpAKy0bLwSYUzAjg+7RmHMfw5i79UPgy95KDd"
+                "username": "Lisa",
+                "email": "sampleaccount2@sampling.com",
+                "id": "arn:aws:iam::123456789013:root",
+                "canonicalId": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf",
+                "arn": "arn:aws:iam::123456789013:root",
+                "accessKey": "accessKey2",
+                "secretKey": "verySecretKey2"
             }
         }
     }

--- a/tests/e2e/scripts/README.md
+++ b/tests/e2e/scripts/README.md
@@ -62,13 +62,17 @@ The main entry point is `run.sh` which supports the following commands:
 
 ## Required Parameters
 
-For tests that interact with S3, the following parameters are required:
+For installation, the following parameters are required:
 
 - `--endpoint-url`: S3 endpoint URL (e.g., <http://localhost:8000>)
-- `--access-key-id`: S3 access key for authentication
-- `--secret-access-key`: S3 secret key for authentication, S3 endpoint should be operational
+- `--access-key-id`: S3 access key for authentication (used to create Kubernetes secret)
+- `--secret-access-key`: S3 secret key for authentication (used to create Kubernetes secret)
 
-These parameters must be passed to both the `install` and `test` commands separately, or to the `all` command which will handle both steps.
+For tests, only the endpoint URL is required:
+
+- `--endpoint-url`: S3 endpoint URL (e.g., <http://localhost:8000>)
+
+Tests use the credentials stored in the Kubernetes secret created during installation.
 
 ## Environment Variables
 
@@ -91,8 +95,11 @@ The `load-credentials.sh` script loads S3 credentials from JSON and exports them
 # Load credentials (uses ../integration_config.json by default)
 source ./load-credentials.sh
 
-# Use with tests
-./run.sh test --endpoint-url http://localhost:8000 --access-key-id "$ACCOUNT1_ACCESS_KEY" --secret-access-key "$ACCOUNT1_SECRET_KEY"
+# Install driver with credentials (creates Kubernetes secret)
+./run.sh install --endpoint-url http://localhost:8000
+
+# Run tests (uses credentials from Kubernetes secret)
+./run.sh test --endpoint-url http://localhost:8000
 
 # Clean up when done
 unset ACCOUNT1_ACCESS_KEY ACCOUNT1_SECRET_KEY ACCOUNT1_CANONICAL_ID ACCOUNT2_ACCESS_KEY ACCOUNT2_SECRET_KEY ACCOUNT2_CANONICAL_ID
@@ -108,27 +115,6 @@ source ./load-credentials.sh --config-file /path/to/config.json
 CREDENTIALS_CONFIG_FILE=/path/to/config.json source ./load-credentials.sh
 ```
 
-### JSON Format
-
-```json
-{
-  "credentials": {
-    "account": {
-      "account1": {
-        "accessKey": "...",
-        "secretKey": "...",
-        "canonicalId": "..."
-      },
-      "account2": {
-        "accessKey": "...",
-        "secretKey": "...",
-        "canonicalId": "..."
-      }
-    }
-  }
-}
-```
-
 ## Usage
 
 Scripts in this directory can be called directly or from the Makefile targets.
@@ -136,31 +122,40 @@ Scripts in this directory can be called directly or from the Makefile targets.
 ### Direct script usage
 
 ```bash
-# Install the driver
-./run.sh install --endpoint-url http://localhost:8000 --access-key-id accessKey1 --secret-access-key verySecretKey1
+# Load credentials first
+source ./load-credentials.sh
 
-# Run tests
-./run.sh test --endpoint-url http://localhost:8000 --access-key-id accessKey1 --secret-access-key verySecretKey1
+# Install the driver (creates Kubernetes secret with credentials)
+./run.sh install --endpoint-url http://localhost:8000
+
+# Run tests (uses credentials from Kubernetes secret)
+./run.sh test --endpoint-url http://localhost:8000
 
 # Run only Go tests
-./run.sh go-test --endpoint-url http://localhost:8000 --access-key-id accessKey1 --secret-access-key verySecretKey1
+./run.sh go-test --endpoint-url http://localhost:8000
 
 # Install and test in one command
-./run.sh all --endpoint-url http://localhost:8000 --access-key-id accessKey1 --secret-access-key verySecretKey1
+./run.sh all --endpoint-url http://localhost:8000
 ```
 
 ### Using Makefile targets
 
 ```bash
-# Install the driver
-make csi-install S3_ENDPOINT_URL=http://localhost:8000 ACCESS_KEY_ID=accessKey1 SECRET_ACCESS_KEY=verySecretKey1
+# Show all available CSI commands
+make help-csi
 
-# Run tests
-make e2e S3_ENDPOINT_URL=http://localhost:8000 ACCESS_KEY_ID=accessKey1 SECRET_ACCESS_KEY=verySecretKey1
+# Load credentials (required)
+source tests/e2e/scripts/load-credentials.sh
+
+# Install the driver (only endpoint URL needed)
+make csi-install S3_ENDPOINT_URL=http://localhost:8000
+
+# Run tests (uses credentials from Kubernetes secret)
+make e2e S3_ENDPOINT_URL=http://localhost:8000
 
 # Run only Go tests
-make e2e-go S3_ENDPOINT_URL=http://localhost:8000 ACCESS_KEY_ID=accessKey1 SECRET_ACCESS_KEY=verySecretKey1
+make e2e-go S3_ENDPOINT_URL=http://localhost:8000
 
 # Install and test in one command
-KUBECONFIG=/Users/anurag4dsb/.kube/config make csi-all S3_ENDPOINT_URL=http://localhost:8000 ACCESS_KEY_ID=accessKey1 SECRET_ACCESS_KEY=verySecretKey1  CSI_IMAGE_TAG=<image-tag> CSI_IMAGE_REPOSITORY=ghcr.io/scality/mountpoint-s3-csi-driver
+make e2e-all S3_ENDPOINT_URL=http://localhost:8000 CSI_IMAGE_TAG=<image-tag> CSI_IMAGE_REPOSITORY=ghcr.io/scality/mountpoint-s3-csi-driver
 ```

--- a/tests/e2e/scripts/README.md
+++ b/tests/e2e/scripts/README.md
@@ -9,6 +9,7 @@ These scripts provide automation for installing, testing, and managing the Scali
 - `uninstall`: Removes the CSI driver from the cluster
 - `all`: Combines install, test, and uninstall operations
 - `go-test`: Runs only the Go-based end-to-end tests
+- `load-credentials.sh`: Loads S3 credentials from JSON configuration file and exports as environment variables
 
 ## Quick Examples
 
@@ -46,6 +47,7 @@ The scripts use a modular design with shared functionality in the `modules/` dir
 
 - `config/`: Default configuration templates
 - `templates/`: YAML templates for Kubernetes resources
+- `../integration_config.json`: S3 credentials configuration file for testing
 
 ## Current Structure
 
@@ -71,12 +73,61 @@ These parameters must be passed to both the `install` and `test` commands separa
 ## Environment Variables
 
 - `KUBECONFIG`: Path to the Kubernetes configuration file (required if not using the default ~/.kube/config)
+- `CREDENTIALS_CONFIG_FILE`: Path to custom credentials JSON file (optional, defaults to `../integration_config.json`)
 
 ## Optional Parameters
 
 - `--namespace`: Specify the namespace to use (default: kube-system)
 - `--skip-go-tests`: Skip executing Go-based end-to-end tests (for test command)
 - `--junit-report`: Generate JUnit XML report at specified path (for test command)
+
+## Credentials Management
+
+The `load-credentials.sh` script loads S3 credentials from JSON and exports them as `ACCOUNT1_*` and `ACCOUNT2_*` environment variables.
+
+### Quick Start
+
+```bash
+# Load credentials (uses ../integration_config.json by default)
+source ./load-credentials.sh
+
+# Use with tests
+./run.sh test --endpoint-url http://localhost:8000 --access-key-id "$ACCOUNT1_ACCESS_KEY" --secret-access-key "$ACCOUNT1_SECRET_KEY"
+
+# Clean up when done
+unset ACCOUNT1_ACCESS_KEY ACCOUNT1_SECRET_KEY ACCOUNT1_CANONICAL_ID ACCOUNT2_ACCESS_KEY ACCOUNT2_SECRET_KEY ACCOUNT2_CANONICAL_ID
+```
+
+### Custom Config File
+
+```bash
+# Use different config file
+source ./load-credentials.sh --config-file /path/to/config.json
+
+# Or with environment variable
+CREDENTIALS_CONFIG_FILE=/path/to/config.json source ./load-credentials.sh
+```
+
+### JSON Format
+
+```json
+{
+  "credentials": {
+    "account": {
+      "account1": {
+        "accessKey": "...",
+        "secretKey": "...",
+        "canonicalId": "..."
+      },
+      "account2": {
+        "accessKey": "...",
+        "secretKey": "...",
+        "canonicalId": "..."
+      }
+    }
+  }
+}
+```
 
 ## Usage
 

--- a/tests/e2e/scripts/load-credentials.sh
+++ b/tests/e2e/scripts/load-credentials.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# load-credentials.sh - Load credentials from JSON configuration file
+
+set -e  # Exit on any error
+
+# Get the directory where this script is located
+if [[ -n "${BASH_SOURCE[0]}" ]]; then
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+else
+    # Fallback for when BASH_SOURCE[0] is empty (when sourced in some contexts)
+    if [[ -f "./load-credentials.sh" ]]; then
+        SCRIPT_DIR="$(pwd)"
+    else
+        SCRIPT_DIR="$(pwd)/tests/e2e/scripts"
+    fi
+fi
+
+# Default config file path
+CONFIG_FILE="${CREDENTIALS_CONFIG_FILE:-${SCRIPT_DIR}/../integration_config.json}"
+
+# Simple logging
+log() { echo "[$(date '+%H:%M:%S')] $1"; }
+error() { echo "[$(date '+%H:%M:%S')] ERROR: $1" >&2; }
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --config-file)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            cat << EOF
+Usage: $0 [OPTIONS]
+
+Load credentials from JSON configuration file and export as environment variables.
+
+Options:
+  --config-file PATH    Specify custom path to credentials JSON file
+  --help               Show this help message
+
+Environment Variables:
+  CREDENTIALS_CONFIG_FILE    Path to credentials JSON file
+
+Examples:
+  source $0                                    # Load with default config
+  source $0 --config-file /path/to/creds.json # Load with custom config
+
+Required JSON structure:
+  {
+    "credentials": {
+      "account": {
+        "account1": { "accessKey": "...", "secretKey": "...", "canonicalId": "..." },
+        "account2": { "accessKey": "...", "secretKey": "...", "canonicalId": "..." }
+      }
+    }
+  }
+EOF
+            return 0 2>/dev/null || exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            return 1 2>/dev/null || exit 1
+            ;;
+    esac
+done
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    error "jq is required but not installed. Please install jq to use this script."
+    return 1 2>/dev/null || exit 1
+fi
+
+# Check if config file exists
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    error "Credentials file not found: $CONFIG_FILE"
+    return 1 2>/dev/null || exit 1
+fi
+
+log "Loading credentials from: $CONFIG_FILE"
+
+# Parse JSON and extract credentials
+ACCOUNT1_ACCESS_KEY=$(jq -r '.credentials.account.account1.accessKey' "$CONFIG_FILE")
+ACCOUNT1_SECRET_KEY=$(jq -r '.credentials.account.account1.secretKey' "$CONFIG_FILE")
+ACCOUNT1_CANONICAL_ID=$(jq -r '.credentials.account.account1.canonicalId' "$CONFIG_FILE")
+
+ACCOUNT2_ACCESS_KEY=$(jq -r '.credentials.account.account2.accessKey' "$CONFIG_FILE")
+ACCOUNT2_SECRET_KEY=$(jq -r '.credentials.account.account2.secretKey' "$CONFIG_FILE")
+ACCOUNT2_CANONICAL_ID=$(jq -r '.credentials.account.account2.canonicalId' "$CONFIG_FILE")
+
+# Basic validation
+if [[ "$ACCOUNT1_ACCESS_KEY" == "null" || -z "$ACCOUNT1_ACCESS_KEY" ]]; then
+    error "Failed to parse account1 accessKey from JSON"
+    return 1 2>/dev/null || exit 1
+fi
+
+if [[ "$ACCOUNT1_SECRET_KEY" == "null" || -z "$ACCOUNT1_SECRET_KEY" ]]; then
+    error "Failed to parse account1 secretKey from JSON"
+    return 1 2>/dev/null || exit 1
+fi
+
+if [[ "$ACCOUNT1_CANONICAL_ID" == "null" || -z "$ACCOUNT1_CANONICAL_ID" ]]; then
+    error "Failed to parse account1 canonicalId from JSON"
+    return 1 2>/dev/null || exit 1
+fi
+
+# Export environment variables
+export ACCOUNT1_ACCESS_KEY
+export ACCOUNT1_SECRET_KEY
+export ACCOUNT1_CANONICAL_ID
+
+# Export account2 credentials if they exist
+if [[ "$ACCOUNT2_ACCESS_KEY" != "null" && -n "$ACCOUNT2_ACCESS_KEY" ]]; then
+    export ACCOUNT2_ACCESS_KEY
+    export ACCOUNT2_SECRET_KEY
+    export ACCOUNT2_CANONICAL_ID
+fi
+
+log "Credentials loaded and exported successfully"
+log "Account1 credentials: ACCOUNT1_ACCESS_KEY=${ACCOUNT1_ACCESS_KEY:0:8}... (truncated)"
+
+# Success message
+echo "✅ Credentials loaded from $CONFIG_FILE"

--- a/tests/e2e/scripts/modules/common.sh
+++ b/tests/e2e/scripts/modules/common.sh
@@ -1,39 +1,33 @@
 #!/bin/bash
 # common.sh - Shared functions for e2e scripts
 
-# Define colors for better readability
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-YELLOW='\033[0;33m'
-NC='\033[0m' # No Color
+# Basic error handling - exit on error, undefined variables, pipe failures
+set -euo pipefail
 
 # Print with timestamp
 log() {
-  echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')] $1${NC}"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
 
 warn() {
-  echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING: $1${NC}"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING: $1"
 }
 
 error() {
-  echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1${NC}" >&2
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1" >&2
   return 1
 }
 
 # Fatal error - logs and exits
 fatal() {
-  echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] FATAL: $1${NC}" >&2
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] FATAL: $1" >&2
   exit 1
 }
 
-# Execute a command
+# Execute a command with logging
 exec_cmd() {
-  # Execute the command
+  log "Executing: $*"
   "$@"
-
-  # Return the exit code from the command
-  return $?
 }
 
 # Check for required tools


### PR DESCRIPTION
This PR modifies E2E workflow to use a JSON file for credentials so we can make it plug and play in Integration
- Added ability to get creds from JSON formatted like that in Integration, also added a script for the same to put this in ENV
- Updated tests and makefile to use this via env
- AI generated change to bash scripts to adopt to new way of installation and running tests 