### PR TITLE
S3CSI-96: use path prefix by default to support FQDN

### DIFF
--- a/.github/scality-storage-deployment/cloudserver-config.json
+++ b/.github/scality-storage-deployment/cloudserver-config.json
@@ -7,7 +7,8 @@
         "cloudserver-front": "us-east-1",
         "s3.docker.test": "us-east-1",
         "127.0.0.2": "us-east-1",
-        "s3.amazonaws.com": "us-east-1"
+        "s3.amazonaws.com": "us-east-1",
+        "s3.scality.com": "us-east-1"
     },
     "websiteEndpoints": [
         "s3-website-us-east-1.amazonaws.com",

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -65,6 +65,26 @@ jobs:
           # Verify the hosts entry
           cat /etc/hosts | grep s3.scality.com
 
+      - name: Configure CoreDNS for S3 FQDN
+        run: |
+          # Get the current CoreDNS ConfigMap
+          kubectl get configmap coredns -n kube-system -o yaml > coredns-original.yaml
+
+          # Add custom hosts entry to CoreDNS
+          kubectl get configmap coredns -n kube-system -o json | \
+          jq --arg ip "${{ steps.get_ip.outputs.host_ip }}" \
+          '.data.Corefile |= sub("ready"; "ready\n        hosts {\n            " + $ip + " s3.scality.com\n            fallthrough\n        }")' | \
+          kubectl apply -f -
+
+          # Restart CoreDNS to pick up changes
+          kubectl rollout restart deployment coredns -n kube-system
+
+          # Wait for CoreDNS to be ready
+          kubectl rollout status deployment coredns -n kube-system --timeout=60s
+
+          # Verify DNS resolution works from within a pod
+          kubectl run dns-test --image=busybox:1.28 --rm -it --restart=Never -- nslookup s3.scality.com
+
       - name: Run Scality Tests
         run: |
           mkdir -p test-results

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Configure CoreDNS for S3 FQDN
         run: |
+          set -e -o pipefail
           # Get the current CoreDNS ConfigMap
           kubectl get configmap coredns -n kube-system -o yaml > coredns-original.yaml
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -59,13 +59,19 @@ jobs:
         id: get_ip
         run: echo "host_ip=$(hostname -I | awk '{print $1}')" >> $GITHUB_OUTPUT
 
+      - name: Configure hosts file for S3 FQDN
+        run: |
+          echo "${{ steps.get_ip.outputs.host_ip }} s3.scality.com" | sudo tee -a /etc/hosts
+          # Verify the hosts entry
+          cat /etc/hosts | grep s3.scality.com
+
       - name: Run Scality Tests
         run: |
           mkdir -p test-results
           # Load credentials from the integration config
           source tests/e2e/scripts/load-credentials.sh
           make e2e-all \
-            S3_ENDPOINT_URL=http://${{ steps.get_ip.outputs.host_ip }}:8000 \
+            S3_ENDPOINT_URL=http://s3.scality.com:8000 \
             CSI_IMAGE_TAG=${{ github.sha }} \
             CSI_IMAGE_REPOSITORY=ghcr.io/${{ github.repository }} \
             ADDITIONAL_ARGS="--junit-report=./test-results/e2e-tests-results.xml"

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -68,6 +68,7 @@ exclude = [
     "^https?://s3\\.ring\\.example\\.com(:[0-9]+)?(/.*)?$",
     "^https?://s3\\.artesca\\.example\\.com(:[0-9]+)?(/.*)?$",
     "^https?://custom-s3\\.example\\.com(:[0-9]+)?(/.*)?$",
+    "^https?://s3\\.scality\\.com(:[0-9]+)?(/.*)?$",
 
     # Exclude AWS URLs with URL-encoded variables (cause 403 errors)
     "^https?://s3\\.amazonaws\\.com/.*\\$\\{.*\\}.*$",

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -141,6 +141,10 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 		args.SetIfAbsent(mountpoint.ArgAllowRoot, mountpoint.ArgNoValue)
 	}
 
+	// Ensure path-style addressing is used by default unless the caller already
+	// specified it explicitly.
+	args.SetIfAbsent(mountpoint.ArgForcePathStyle, mountpoint.ArgNoValue)
+
 	klog.V(4).Infof("NodePublishVolume: mounting %s at %s with options %v", bucket, target, args.SortedList())
 
 	credentialCtx := credentialProvideContextFromPublishRequest(req, args)

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -106,7 +106,7 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only"})))
+					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--force-path-style"})))
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -144,7 +144,7 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--bar", "--foo", "--read-only", "--test=123"})))
+					gomock.Eq(mountpoint.ParseArgs([]string{"--bar", "--foo", "--read-only", "--test=123", "--force-path-style"})))
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -182,7 +182,7 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--test=123"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--test=123", "--force-path-style"}))).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -256,7 +256,7 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660", "--force-path-style"}))).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -294,7 +294,7 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660", "--force-path-style"}))).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -332,7 +332,7 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-root"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-root", "--force-path-style"}))).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -370,7 +370,7 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-other"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-other", "--force-path-style"}))).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -384,7 +384,7 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				nodeTestEnv := initNodeServerTestEnv(t)
 				ctx := context.Background()
-				mountFlags := []string{"--gid 456", "--allow-other", "--dir-mode=555", "--file-mode=444"}
+				mountFlags := []string{"--gid 456", "--allow-other", "--dir-mode=555", "--file-mode=444", "--force-path-style"}
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{

--- a/pkg/mountpoint/args.go
+++ b/pkg/mountpoint/args.go
@@ -20,6 +20,7 @@ const (
 	ArgGid                             = "--gid"
 	ArgDirMode                         = "--dir-mode"
 	ArgFileMode                        = "--file-mode"
+	ArgForcePathStyle                  = "--force-path-style"
 	ArgProfile                         = "--profile"            // stripped – Driver only supports static Keys, profile is for EKS/EC2 environments
 	ArgEndpointURL                     = "--endpoint-url"       // stripped – cluster‑admin controls S3 endpoints
 	ArgStorageClass                    = "--storage-class"      // stripped – driver forces bucket default (STANDARD)


### PR DESCRIPTION
This is needed to support S3 URL  which are FQDNs and not just IP addresses. Scality S3  specific.

Also updated e2e tests