### PR TITLE
S3CSI-97: Enhance footer and side author and description

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,9 @@ theme:
 extra_css:
   - assets/css/custom.css
 
+extra:
+  generator: false
+
 plugins:
   - search
   - mermaid2
@@ -75,7 +78,7 @@ markdown_extensions:
           format: pymdownx.superfences.fence_div_format
 
 copyright: |
-  Copyright &copy; 2025 Scality, Inc. All rights reserved. |
+  Copyright © 2025 Scality, Inc. Licensed under the
   <a href="https://github.com/scality/mountpoint-s3-csi-driver/blob/main/LICENSE">Apache License 2.0</a>
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: "Scality S3 CSI Driver"
+site_description: Documentation for Scality S3 CSI Driver.
+site_author: "Scality Engineering"
 site_url: https://scality.github.io/mountpoint-s3-csi-driver
 repo_url: https://github.com/scality/mountpoint-s3-csi-driver
 edit_uri: edit/main/docs/            # ← branch that holds Markdown


### PR DESCRIPTION
- Improved text for copyright to align with Apache license
- Removed footer for "Built with Mkdocs"
- Added details about author and description