### PR TITLE
chore(S3CSI-99): bump version to 1.1.0 for charts and binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=1.0.0
+VERSION=1.1.0
 
 # List of allowed licenses in the CSI Driver's dependencies.
 # See https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28 for list of canonical names for licenses.

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/scality/mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0.0"
+  tag: "1.1.0"
 
 # Node plugin configuration (DaemonSet)
 node:


### PR DESCRIPTION
- Update chart version to 1.1.0
- Update binary version to 1.1.0
- Prepare for v1.1.0 release

Note to reviewers: All references of 1.0.0 in docs will be chnaged in subsequent PRs in S3CSI-98 once we have versioned docs.