### PR TITLE
S3CSI-98: introduce conventional commits (Part 1/5 for automated changelogs and versioned docs)

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,106 @@
+# Commitizen configuration for Scality S3 CSI Driver conventional commits
+# Enforces standardized commit messages with issue ID validation for automated changelog generation
+
+[tool.commitizen]
+# Core commitizen settings for conventional commits and versioning
+# https://www.conventionalcommits.org/en/v1.0.0/
+name = "cz_conventional_commits"                # Use conventional commits specification
+tag_format = "$version"                         # Git tag format without 'v' prefix (matches project standard)
+version_scheme = "semver"                       # Semantic versioning (major.minor.patch)
+version_provider = "git"                        # Derive version from git tags
+update_changelog_on_bump = true                 # Auto-update CHANGELOG.md on version bumps
+major_version_zero = true                       # Allow 0.x.x versions for pre-1.0 releases
+
+[tool.commitizen.customize]
+# Custom commit message template and validation rules
+message_template = "{{change_type}}{% if scope %}({{scope}}){% endif %}: {{subject}}{% if body %}\n\n{{body}}{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"
+example = "feat(S3CSI-123): add custom S3 endpoint support"
+
+# Commit message schema documentation for developers
+schema = """
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+"""
+
+# Regex pattern to validate commit message format (enforces conventional commits)
+schema_pattern = "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|breaking)(?:\\([A-Z]+-\\d+\\))?(?:\\([^)]*\\))?: .{1,50}"
+
+# Order of change types in generated changelogs (user-facing changes first)
+change_type_order = ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]
+
+# Interactive prompts for guided commit creation with `cz commit`
+[[tool.commitizen.customize.questions]]
+type = "list"
+name = "change_type"
+message = "Select the type of change you are committing:"
+choices = [
+    # User-facing changes (require issue ID for traceability)
+    { value = "feat", name = "feat: A new feature (user-facing)" },
+    { value = "fix", name = "fix: A bug fix (user-facing)" },
+    { value = "perf", name = "perf: A performance improvement (user-facing)" },
+    { value = "security", name = "security: A security update (user-facing)" },
+    { value = "breaking", name = "breaking: A breaking change (user-facing)" },
+    # Development changes (issue ID optional)
+    { value = "docs", name = "docs: Documentation only changes" },
+    { value = "style", name = "style: Code style changes (formatting, etc)" },
+    { value = "refactor", name = "refactor: Code refactoring" },
+    { value = "test", name = "test: Adding or updating tests" },
+    { value = "build", name = "build: Build system or dependencies" },
+    { value = "ci", name = "ci: CI/CD pipeline changes" },
+    { value = "chore", name = "chore: Maintenance tasks" },
+    { value = "revert", name = "revert: Revert a previous commit" }
+]
+
+# Prompt for issue ID or component scope
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "scope"
+message = "Issue ID (e.g., S3CSI-123) [REQUIRED for feat/fix/perf/security/breaking]:"
+
+# Prompt for commit subject line (imperative mood, concise description)
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "subject"
+message = "Write a short, imperative description of the change:"
+
+# Optional commit body for additional context
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "body"
+message = "Provide additional contextual information (optional):"
+
+# Optional footer for breaking changes and issue references
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "footer"
+message = "Information about breaking changes, issue references (optional):"
+
+# Parser configuration for analyzing existing commits in changelog generation
+[tool.commitizen.customize.commit_parser]
+pattern = "^(?P<change_type>feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|breaking)(?:\\((?P<scope>[^)]+)\\))?:?\\s(?P<message>.*)"
+schema = "<type>(<scope>): <subject>"
+
+# Template for generating structured changelogs from conventional commits
+[tool.commitizen.customize.changelog]
+template = """
+## {{version}} ({{date}})
+
+{% for group, commits in commits | groupby("change_type") -%}
+### {{group | title}}
+{% for commit in commits %}
+- {{commit.scope}}: {{commit.message}} {% if commit.scope %}({{commit.scope}}){% endif %}
+{%- endfor %}
+
+{% endfor %}
+"""
+
+# Semantic versioning rules based on commit types for automated version bumping
+[tool.commitizen.customize.bump_pattern]
+"^BREAKING CHANGE" = "MAJOR"                    # Breaking changes increment major version (1.0.0 → 2.0.0)
+"^feat" = "MINOR"                               # New features increment minor version (1.0.0 → 1.1.0)
+"^fix" = "PATCH"                                # Bug fixes increment patch version (1.0.0 → 1.0.1)
+"^perf" = "PATCH"                               # Performance improvements increment patch version
+"^security" = "PATCH"                           # Security updates increment patch version

--- a/.github/commit-template.txt
+++ b/.github/commit-template.txt
@@ -1,0 +1,36 @@
+# <type>(<scope>): <description>
+#
+# [optional body]
+#
+# [optional footer(s)]
+
+# Type (choose one):
+#   feat      New feature (user-facing, REQUIRES issue ID)
+#   fix       Bug fix (user-facing, REQUIRES issue ID)
+#   perf      Performance improvement (user-facing, REQUIRES issue ID)
+#   security  Security update (user-facing, REQUIRES issue ID)
+#   breaking  Breaking change (user-facing, REQUIRES issue ID)
+#   docs      Documentation changes
+#   style     Code formatting, no logic changes
+#   refactor  Code refactoring
+#   test      Adding or updating tests
+#   build     Build system or dependencies
+#   ci        CI/CD pipeline changes
+#   chore     Maintenance tasks
+#   revert    Revert a previous commit
+
+# Scope:
+#   - For user-facing changes: MUST be issue ID (S3CSI-123)
+#   - For development changes: Optional (component name, issue ID, or omit)
+
+# Description:
+#   - Use imperative mood: "add" not "added"
+#   - Start with lowercase letter
+#   - No period at the end
+#   - Keep under 72 characters
+
+# Examples:
+#   feat(S3CSI-123): add custom S3 endpoint support
+#   fix(S3CSI-456): resolve authentication timeout with RING
+#   docs: update installation guide for v1.1.0
+#   chore(deps): bump mkdocs from 1.5.0 to 1.6.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "pip"
+      prefix: "chore"
+      prefix-development: "deps-pip"
       include: "scope"
     labels:
       - "dependencies"
@@ -23,7 +24,8 @@ updates:
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "gomod"
+      prefix: "chore"
+      prefix-development: "deps-gomod"
       include: "scope"
     labels:
       - "gomod"
@@ -66,7 +68,8 @@ updates:
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "gomod"
+      prefix: "chore"
+      prefix-development: "deps-gomod-e2e"
       include: "scope"
     labels:
       - "gomod"
@@ -103,7 +106,8 @@ updates:
       time: "08:00"
       timezone: "Europe/Paris"
     commit-message:
-      prefix: "github-actions"
+      prefix: "chore"
+      prefix-development: "deps-actions"
       include: "scope"
     labels:
       - "github-actions"

--- a/.github/scripts/validate-commit.py
+++ b/.github/scripts/validate-commit.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Advanced commit message validation for conventional commits with issue ID support.
+
+This script validates commit messages according to the Conventional Commits specification
+with additional requirements for issue IDs on user-facing changes.
+
+Requirements:
+- User-facing commits (feat, fix, perf, security, breaking) MUST have issue IDs
+- Development commits (docs, test, ci, chore, refactor, style, build) MAY have issue IDs
+- Issue ID format: S3CSI-123 or GitHub issue references
+- Commit message format: type(scope): description
+"""
+
+import re
+import sys
+import argparse
+from typing import Optional, Tuple, List
+
+
+class CommitValidator:
+    """Validates commit messages according to conventional commit standards."""
+
+    # User-facing commit types that REQUIRE issue IDs
+    USER_FACING_TYPES = {'feat', 'fix', 'perf', 'security', 'breaking'}
+
+    # Development commit types where issue IDs are OPTIONAL
+    DEVELOPMENT_TYPES = {'docs', 'test', 'ci', 'chore', 'refactor', 'style', 'build', 'revert'}
+
+    # All valid commit types
+    ALL_TYPES = USER_FACING_TYPES | DEVELOPMENT_TYPES
+
+    # Issue ID patterns
+    JIRA_PATTERN = r'S3CSI-\d+'
+    GITHUB_ISSUE_PATTERN = r'#\d+'
+
+    # Conventional commit pattern
+    COMMIT_PATTERN = re.compile(
+        r'^(?P<type>\w+)(?:\((?P<scope>[^)]+)\))?: (?P<description>.+)$'
+    )
+
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def validate_commit_message(self, message: str) -> Tuple[bool, List[str], List[str]]:
+        """
+        Validate a commit message.
+
+        Returns:
+            Tuple of (is_valid, errors, warnings)
+        """
+        self.errors = []
+        self.warnings = []
+
+        # Split message into lines and filter out comments
+        lines = [line for line in message.strip().split('\n') if line.strip() and not line.strip().startswith('#')]
+        if not lines:
+            self.errors.append("Commit message cannot be empty (ignoring template comments)")
+            return False, self.errors, self.warnings
+
+        subject_line = lines[0]
+
+        # Validate basic format
+        match = self.COMMIT_PATTERN.match(subject_line)
+        if not match:
+            self.errors.append(
+                f"Invalid commit format. Expected: type(scope): description\n"
+                f"Got: {subject_line}\n"
+                f"Examples:\n"
+                f"  feat(S3CSI-123): add custom S3 endpoint support\n"
+                f"  fix(S3CSI-456): resolve authentication timeout issue\n"
+                f"  docs: update installation guide"
+            )
+            return False, self.errors, self.warnings
+
+        commit_type = match.group('type').lower()
+        scope = match.group('scope') or ''
+        description = match.group('description')
+
+        # Validate commit type
+        if commit_type not in self.ALL_TYPES:
+            self.errors.append(
+                f"Invalid commit type '{commit_type}'. "
+                f"Valid types: {', '.join(sorted(self.ALL_TYPES))}"
+            )
+            return False, self.errors, self.warnings
+
+        # Validate description length
+        if len(description) < 10:
+            self.errors.append("Description must be at least 10 characters long")
+
+        if len(description) > 72:
+            self.warnings.append("Description should be 72 characters or less for better readability")
+
+        # Validate issue ID requirements
+        self._validate_issue_id(commit_type, scope, description, message)
+
+        # Additional validations
+        self._validate_description_style(description)
+
+        return len(self.errors) == 0, self.errors, self.warnings
+
+    def _validate_issue_id(self, commit_type: str, scope: str, description: str, full_message: str):
+        """Validate issue ID requirements based on commit type."""
+        has_jira_id = bool(re.search(self.JIRA_PATTERN, scope)) if scope else False
+        has_github_issue = bool(re.search(self.GITHUB_ISSUE_PATTERN, full_message))
+        has_issue_id = has_jira_id or has_github_issue
+
+        if commit_type in self.USER_FACING_TYPES:
+            if not has_issue_id:
+                self.errors.append(
+                    f"User-facing commit type '{commit_type}' requires an issue ID.\n"
+                    f"Include issue ID in scope: {commit_type}(S3CSI-123): description\n"
+                    f"Or reference GitHub issue in footer: Closes #123"
+                )
+            elif has_jira_id and not re.match(r'^S3CSI-\d+$', scope):
+                self.errors.append(
+                    f"Invalid JIRA issue format in scope. Expected: S3CSI-123, got: {scope}"
+                )
+        elif commit_type in self.DEVELOPMENT_TYPES:
+            # Issue ID is optional for development commits
+            if scope and not (has_jira_id or scope.replace('-', '').replace('_', '').isalnum()):
+                self.warnings.append(
+                    f"Scope '{scope}' doesn't look like an issue ID or component name"
+                )
+
+    def _validate_description_style(self, description: str):
+        """Validate description style guidelines."""
+        # Should start with lowercase (imperative mood)
+        if description and description[0].isupper():
+            self.warnings.append(
+                "Description should start with lowercase letter (imperative mood). "
+                "E.g., 'add feature' not 'Add feature'"
+            )
+
+        # Should not end with period
+        if description.endswith('.'):
+            self.warnings.append("Description should not end with a period")
+
+        # Should be imperative mood
+        if any(description.lower().startswith(word) for word in ['added', 'fixed', 'updated', 'changed']):
+            self.warnings.append(
+                "Use imperative mood: 'add' not 'added', 'fix' not 'fixed'"
+            )
+
+
+def main():
+    """Main entry point for commit message validation."""
+    parser = argparse.ArgumentParser(description='Validate conventional commit messages')
+    parser.add_argument('commit_file', nargs='?', help='File containing commit message')
+    parser.add_argument('--message', '-m', help='Commit message to validate')
+    parser.add_argument('--strict', action='store_true', help='Treat warnings as errors')
+
+    args = parser.parse_args()
+
+    # Get commit message
+    if args.message:
+        commit_message = args.message
+    elif args.commit_file:
+        try:
+            with open(args.commit_file, 'r', encoding='utf-8') as f:
+                commit_message = f.read()
+        except FileNotFoundError:
+            print(f"❌ Error: Commit file '{args.commit_file}' not found")
+            sys.exit(1)
+        except Exception as e:
+            print(f"❌ Error reading commit file: {e}")
+            sys.exit(1)
+    else:
+        # Read from stdin
+        commit_message = sys.stdin.read()
+
+    # Validate commit message
+    validator = CommitValidator()
+    is_valid, errors, warnings = validator.validate_commit_message(commit_message)
+
+    # Print results
+    if errors:
+        print("❌ Commit message validation failed:")
+        for error in errors:
+            print(f"   {error}")
+        print()
+
+    if warnings:
+        print("⚠️  Commit message warnings:")
+        for warning in warnings:
+            print(f"   {warning}")
+        print()
+
+    if is_valid and not warnings:
+        print("✅ Commit message is valid!")
+    elif is_valid:
+        print("✅ Commit message is valid (with warnings)")
+
+    # Exit with appropriate code
+    if not is_valid or (args.strict and warnings):
+        print("\n📚 Conventional Commit Examples:")
+        print("   feat(S3CSI-123): add custom S3 endpoint support")
+        print("   fix(S3CSI-456): resolve authentication timeout issue")
+        print("   docs: update installation guide")
+        print("   chore(deps): bump mkdocs from 1.5.0 to 1.6.0")
+        print("   breaking(S3CSI-789): remove deprecated API endpoints")
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
         args: [--config, .markdownlint.yaml, --fix]
         types: [markdown]
 
+  # Conventional Commits validation
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.8.3  # Latest version as of June 2025
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
+
   - repo: https://github.com/lycheeverse/lychee
     rev: lychee-v0.18.1  # Latest stable version
     hooks:
@@ -30,6 +37,15 @@ repos:
 
   - repo: local
     hooks:
+      # Advanced commit message validation with issue ID support
+      # Validates conventional commits with stricter rules than default commitizen
+      # Requires issue IDs for user-facing changes (feat, fix, perf, security, breaking)
+      # Optional issue IDs for development changes (docs, test, ci, chore, etc.)
+      - id: validate-commit-message
+        name: validate commit message
+        entry: python3 .github/scripts/validate-commit.py
+        language: system
+        stages: [commit-msg]
       # golangci-lint with Linux build environment to match CI
       # Uses .golangci.yaml configuration automatically
       # GOOS=linux ensures we analyze the same files as CI (including Linux-specific files)

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,65 @@
+# Developer Resources
+
+Welcome to the Scality S3 CSI Driver development environment! This directory contains all the tools and documentation needed for contributing to the project.
+
+## Quick Setup
+
+```bash
+# 1. Run setup script
+./scripts/setup-dev-tools.sh
+
+# 2. Activate virtual environment for commitizen tools
+source venv/bin/activate
+
+# 3. Start using conventional commits
+cz commit
+```
+
+This script will install and configure all necessary development tools automatically.
+
+## Directory Structure
+
+- `docs/` - Internal development documentation
+- `scripts/` - Development automation scripts
+
+## What Gets Installed
+
+The setup script configures:
+
+- Conventional commit tools (Commitizen, pre-commit hooks)
+- Go development tools (golangci-lint, goimports, gofumpt)
+- IDE integration (VS Code extensions and settings)
+- Git hooks for automated validation
+
+## Development Workflow
+
+1. Run setup script once: `./scripts/setup-dev-tools.sh`
+2. Activate virtual environment: `source venv/bin/activate`
+3. Create feature branch: `git checkout -b feature/your-feature`
+4. Make changes following our standards
+5. Commit with conventional format: `cz commit`
+6. Push and create pull request
+
+## Key Benefits
+
+- Consistent development workflow across team members
+- Automated code formatting and linting
+- Conventional commits for automated changelog generation
+- Pre-commit validation to catch issues early
+- IDE integration for better developer experience
+
+## Documentation
+
+- **[Conventional Commits Guide](docs/conventional-commits.md)** - Complete guide for standardized commit messages
+- **[Scripts Documentation](scripts/README.md)** - Information about development scripts
+
+## Purpose
+
+This directory helps maintain:
+
+- Consistent development workflow across the team
+- Automated tooling for code quality and commit standards
+- Clear separation between developer resources and user-facing documentation
+- Easy onboarding for new contributors
+
+The content here is separate from the user-facing documentation in `/docs` which is published via MkDocs.

--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -1,0 +1,30 @@
+# Internal Development Documentation
+
+This directory contains documentation for developers contributing to the Scality S3 CSI Driver project.
+
+## Files
+
+### `conventional-commits.md`
+
+Comprehensive guide for writing standardized commit messages using the Conventional Commits specification.
+
+**Contents:**
+
+- Commit message format and requirements
+- Issue ID requirements for different commit types
+- Examples of good and bad commit messages
+- Troubleshooting common validation errors
+- Tools and setup instructions
+
+This guide is for internal development use and is not published with the user-facing documentation.
+
+## Purpose
+
+This documentation helps maintain:
+
+- Consistent commit message formatting across the team
+- Automated changelog generation from commit messages
+- Clear development workflow and standards
+- Proper issue tracking and traceability
+
+The documentation here is separate from the user-facing docs in the `/docs` directory which are published via MkDocs.

--- a/dev/docs/conventional-commits.md
+++ b/dev/docs/conventional-commits.md
@@ -1,0 +1,239 @@
+# Conventional Commits Guide
+
+This guide explains how to write conventional commits for the Scality S3 CSI Driver project.
+
+## What are Conventional Commits
+
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) provide a structured format for commit messages that enables automated changelog generation, semantic versioning,
+and better project history tracking.
+
+Our project uses conventional commits to automatically generate changelogs and determine version bumps based on the types of changes made.
+
+## Commit Message Format
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+All parts explained below:
+
+### Type (Required)
+
+**User-facing changes (require issue ID):**
+
+- `feat` - New feature for users
+- `fix` - Bug fix that affects users
+- `perf` - Performance improvement
+- `security` - Security-related changes
+- `breaking` - Breaking changes (also add `BREAKING CHANGE:` in footer)
+
+**Development changes (issue ID optional):**
+
+- `docs` - Documentation changes
+- `test` - Adding or updating tests
+- `ci` - CI/CD pipeline changes
+- `chore` - Maintenance tasks, dependency updates
+
+### Scope (Conditional)
+
+**Issue ID Requirements:**
+
+- Format: `S3CSI-123` (Jira ticket number)
+- Required for: feat, fix, perf, security, breaking
+- Optional for: docs, test, ci, chore
+
+**Examples:**
+
+- Issue ID: `S3CSI-123`
+- Component: `controller`, `node`, `helm`, `docs`
+
+### Description (Required)
+
+- Use imperative mood: "add" not "added" or "adds"
+- Start with lowercase letter
+- No period at the end
+- Maximum 50 characters
+- Be concise but descriptive
+
+## Examples
+
+### User-Facing Changes (Require Issue ID)
+
+```bash
+feat(S3CSI-123): add custom S3 endpoint support
+fix(S3CSI-456): resolve authentication timeout with RING
+perf(S3CSI-789): optimize mount performance for large files
+security(S3CSI-321): update dependencies to fix CVE-2023-1234
+```
+
+### Development Changes (Issue ID Optional)
+
+```bash
+docs: update installation guide
+test: add unit tests for volume controller
+ci: add automated security scanning
+chore(deps): bump mkdocs from 1.5.0 to 1.6.0
+```
+
+### Breaking Changes
+
+```bash
+breaking(S3CSI-555): remove deprecated mount options
+
+BREAKING CHANGE: The legacy mount options `cache-dir` and `cache-size`
+have been removed. Use `local-cache-dir` and `local-cache-size` instead.
+```
+
+### With Body and Footer
+
+```bash
+feat(S3CSI-123): add support for custom S3 endpoints
+
+This change allows users to specify custom S3-compatible endpoints
+for use with private cloud storage solutions like RING.
+
+The implementation includes:
+- New volumeContext parameter: customEndpoint
+- Validation of endpoint URLs
+- Integration with existing authentication mechanisms
+
+Closes S3CSI-123
+Refs S3CSI-100
+```
+
+## Issue ID Requirements
+
+### Required for User-Facing Changes
+
+These commit types **must** include an issue ID because they affect users and appear in release notes:
+
+- `feat` - New features
+- `fix` - Bug fixes
+- `perf` - Performance improvements
+- `security` - Security updates
+- `breaking` - Breaking changes
+
+### Optional for Development Changes
+
+These commit types **may** include an issue ID but it's not required:
+
+- `docs` - Documentation updates
+- `test` - Test additions/updates
+- `ci` - CI/CD changes
+- `chore` - Maintenance tasks
+
+## How to Create Commits
+
+### Option 1: Using Commitizen (Recommended)
+
+After making your changes, use the interactive commit tool:
+
+```bash
+# Interactive commit creation
+cz commit
+```
+
+Commitizen will guide you through:
+
+1. Selecting commit type
+2. Entering scope/issue ID
+3. Writing description
+4. Adding body and footer if needed
+
+### Option 2: Manual Commits
+
+If you prefer writing commits manually:
+
+```bash
+git commit -m "feat(S3CSI-123): add custom S3 endpoint support"
+```
+
+### Option 3: Git Commit Template
+
+Use the provided commit template:
+
+```bash
+# Set up the template (done automatically by setup script)
+git config commit.template .github/commit-template.txt
+
+# Create commits with template
+git commit
+```
+
+## Validation and Pre-commit Hooks
+
+Our pre-commit hooks automatically validate commit messages. If validation fails:
+
+1. Read the error message carefully
+2. Fix the commit message format
+3. Try committing again
+
+Common validation errors:
+
+### Missing Issue ID
+
+```bash
+# Error: feat commits require issue ID in scope
+# Wrong: feat: add custom S3 endpoint support
+# Fix:
+git commit --amend -m "feat(S3CSI-123): add custom S3 endpoint support"
+```
+
+### Invalid Format
+
+```bash
+# Error: commit doesn't follow type(scope): description format
+# Wrong: Add custom S3 endpoint support
+# Fix:
+git commit --amend -m "feat(S3CSI-123): add custom S3 endpoint support"
+```
+
+### Description Too Short
+
+```bash
+# Error: description must be at least 10 characters long
+# Wrong: feat(S3CSI-123): add support
+# Fix:
+git commit --amend -m "feat(S3CSI-123): add comprehensive S3 endpoint support"
+```
+
+### Subject Line Too Long
+
+```bash
+# Error: subject line exceeds 55 characters for optimal Git log readability
+# Wrong: feat(S3CSI-123): add comprehensive S3 endpoint support with advanced configuration options
+# Fix:
+git commit --amend -m "feat(S3CSI-123): add comprehensive S3 endpoint support"
+```
+
+## IDE Integration
+
+### VS Code
+
+The setup script configures VS Code with:
+
+- Conventional Commits extension
+- Git commit message templates
+- Automated formatting on save
+
+### Other IDEs
+
+For other IDEs, manually configure:
+
+- Git commit template: `.github/commit-template.txt`
+- Pre-commit hooks will still validate commits
+
+## Migration Strategy
+
+For existing contributors:
+
+- **New commits** MUST follow conventional format
+- **Existing commits** don't need to be changed
+- **Squash commits** in PRs to ensure clean history
+- **Release notes** will be generated from conventional commits going forward
+
+This ensures a smooth transition while maintaining project history.

--- a/dev/scripts/README.md
+++ b/dev/scripts/README.md
@@ -1,0 +1,37 @@
+# Development Scripts
+
+This directory contains automation scripts for setting up and maintaining the development environment.
+
+## setup-dev-tools.sh
+
+The main development environment setup script that configures all necessary tools for contributing to the project.
+
+### What it does
+
+- Installs Commitizen for interactive commit creation
+- Sets up pre-commit hooks for automated validation
+- Configures Go development tools (golangci-lint, goimports, gofumpt)
+- Sets up IDE integration (VS Code extensions and settings)
+- Configures git commit templates and hooks
+
+### Usage
+
+```bash
+# Run from repository root
+./dev/scripts/setup-dev-tools.sh
+```
+
+### Requirements
+
+- Python 3 and pip3
+- Go 1.19 or later
+- Git
+
+### Installed Tools
+
+- `commitizen==4.8.3` - Interactive commit message creation
+- `pre-commit==4.0.1` - Git hook management and validation
+- `golangci-lint` - Go code linting and formatting
+- `goimports` and `gofumpt` - Go code formatting
+
+After running this script, you'll be ready to use conventional commits with validation and automated tooling.

--- a/dev/scripts/setup-dev-tools.sh
+++ b/dev/scripts/setup-dev-tools.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Setup script for development tools and conventional commits
+# Run this script to configure your local development environment
+
+set -e
+
+echo "Setting up development tools for Scality S3 CSI Driver..."
+
+print_status() {
+    echo "[INFO] $1"
+}
+
+print_success() {
+    echo "[SUCCESS] $1"
+}
+
+print_warning() {
+    echo "[WARNING] $1"
+}
+
+print_error() {
+    echo "[ERROR] $1"
+}
+
+# Check if we're in the right directory
+if [[ ! -f "go.mod" ]] || [[ ! -d "pkg" ]]; then
+    print_error "This script must be run from the root of the mountpoint-s3-active-dev repository"
+    exit 1
+fi
+
+# Check Python installation
+print_status "Checking Python installation..."
+if ! command -v python3 &> /dev/null; then
+    print_error "Python 3 is required but not installed"
+    exit 1
+fi
+print_success "Python 3 found: $(python3 --version)"
+
+# Check pip installation
+if ! command -v pip3 &> /dev/null; then
+    print_error "pip3 is required but not installed"
+    exit 1
+fi
+
+# Set up Python virtual environment for MkDocs and documentation tools
+print_status "Setting up Python virtual environment..."
+if [[ ! -d "venv" ]]; then
+    python3 -m venv venv
+    print_success "Virtual environment created"
+else
+    print_success "Virtual environment already exists"
+fi
+
+# Activate virtual environment and install requirements
+print_status "Installing Python dependencies..."
+source venv/bin/activate
+pip install -r requirements.txt
+print_success "Python dependencies installed"
+
+# Install Commitizen
+print_status "Installing Commitizen for conventional commits..."
+if pip show commitizen &> /dev/null; then
+    print_success "Commitizen already installed: $(cz version)"
+else
+    pip install commitizen==4.8.3
+    print_success "Commitizen installed successfully"
+fi
+
+# Install pre-commit
+print_status "Installing pre-commit hooks..."
+if command -v pre-commit &> /dev/null; then
+    print_success "pre-commit already installed: $(pre-commit --version)"
+else
+    pip install pre-commit==4.0.1
+    print_success "pre-commit installed successfully"
+fi
+
+# Install pre-commit hooks
+print_status "Installing pre-commit hooks for this repository..."
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+print_success "Pre-commit hooks installed"
+
+# Set up git commit template
+print_status "Setting up git commit template..."
+git config commit.template .github/commit-template.txt
+print_success "Git commit template configured"
+
+# Check if Go tools are installed
+print_status "Checking Go development tools..."
+
+# Check golangci-lint
+if ! command -v golangci-lint &> /dev/null; then
+    print_warning "golangci-lint not found. Installing..."
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.2
+    print_success "golangci-lint installed"
+else
+    print_success "golangci-lint found: $(golangci-lint --version)"
+fi
+
+# Check goimports
+if ! command -v goimports &> /dev/null; then
+    print_warning "goimports not found. Installing..."
+    go install golang.org/x/tools/cmd/goimports@latest
+    print_success "goimports installed"
+else
+    print_success "goimports found"
+fi
+
+# Check gofumpt
+if ! command -v gofumpt &> /dev/null; then
+    print_warning "gofumpt not found. Installing..."
+    go install mvdan.cc/gofumpt@latest
+    print_success "gofumpt installed"
+else
+    print_success "gofumpt found"
+fi
+
+# Set up VS Code settings (if .vscode directory exists)
+if [[ -d ".vscode" ]]; then
+    print_status "Setting up VS Code configuration..."
+
+    # Create settings.json if it doesn't exist
+    if [[ ! -f ".vscode/settings.json" ]]; then
+        cat > .vscode/settings.json << 'EOF'
+{
+    "conventionalCommits.scopes": [
+        "S3CSI-123",
+        "docs",
+        "ci",
+        "deps",
+        "helm",
+        "test"
+    ],
+    "git.inputValidation": "always",
+    "git.useCommitInputAsStashMessage": true,
+    "gitlens.advanced.messages": {
+        "suppressCommitHasNoPreviousCommitWarning": false
+    },
+    "go.formatTool": "gofumpt",
+    "go.lintTool": "golangci-lint",
+    "go.lintOnSave": "package",
+    "[go]": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
+    }
+}
+EOF
+        print_success "VS Code settings.json created"
+    else
+        print_success "VS Code settings.json already exists"
+    fi
+
+    # Create extensions.json for recommended extensions
+    if [[ ! -f ".vscode/extensions.json" ]]; then
+        cat > .vscode/extensions.json << 'EOF'
+{
+    "recommendations": [
+        "golang.go",
+        "vivaxy.vscode-conventional-commits",
+        "ms-vscode.vscode-json",
+        "redhat.vscode-yaml",
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "eamodio.gitlens"
+    ]
+}
+EOF
+        print_success "VS Code extensions.json created"
+    else
+        print_success "VS Code extensions.json already exists"
+    fi
+fi
+
+# Test the setup
+print_status "Testing the setup..."
+
+# Test pre-commit hooks
+print_status "Testing pre-commit hooks..."
+if pre-commit run --all-files &> /dev/null; then
+    print_success "Pre-commit hooks test passed"
+else
+    print_warning "Pre-commit hooks found some issues (this is normal for first run)"
+fi
+
+# Test commitizen
+print_status "Testing commitizen..."
+if cz --help &> /dev/null; then
+    print_success "Commitizen test passed"
+else
+    print_error "Commitizen test failed"
+fi
+
+# Final instructions
+echo
+echo "Development environment setup complete!"
+echo
+echo "IMPORTANT: To use the tools, activate the virtual environment:"
+echo "  source venv/bin/activate"
+echo
+echo "Next steps:"
+echo "1. Activate venv: source venv/bin/activate"
+echo "2. Try making a commit with: cz commit"
+echo "3. Or use manual format: git commit -m \"feat(S3CSI-123): add new feature\""
+echo "4. Read the guide: dev/docs/conventional-commits.md"
+echo
+echo "Available commands (after activating venv):"
+echo "  cz commit        - Interactive commit creation"
+echo "  cz bump          - Bump version based on commits"
+echo "  cz changelog     - Generate changelog"
+echo "  pre-commit run   - Run all pre-commit hooks"
+echo
+echo "Documentation:"
+echo "  - Conventional Commits Guide: dev/docs/conventional-commits.md"
+echo "  - Pre-commit configuration: .pre-commit-config.yaml"
+echo "  - Commitizen configuration: .cz.toml"
+echo
+print_success "Happy coding! Don't forget to: source venv/bin/activate"


### PR DESCRIPTION
-  Set up pre-commit hooks for conventional commits
- Create commit message validation with issue ID support
- Add team guidelines and documentation for conventional commits
- Configure IDE integration and developer tooling
- Update Dependabot configuration for conventional commits