### PR TITLE
S3CSI-98: Add mike configuration for manual deployment of already published 1.0 docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: "Scality S3 CSI Driver"
-site_description: Documentation for Scality S3 CSI Driver.
-site_author: "Scality Engineering"
-site_url: https://scality.github.io/mountpoint-s3-csi-driver
-repo_url: https://github.com/scality/mountpoint-s3-csi-driver
-edit_uri: edit/main/docs/            # ← branch that holds Markdown
+site_name: 'Scality S3 CSI Driver'
+site_description: 'Documentation for Scality S3 CSI Driver'
+site_author: 'Scality Engineering'
+site_url: 'https://scality.github.io/mountpoint-s3-csi-driver/'
+repo_url: 'https://github.com/scality/mountpoint-s3-csi-driver'
+edit_uri: 'edit/main/docs/'            # ← branch that holds Markdown
 
 theme:
   logo: assets/images/Scality_logo.png
@@ -49,6 +49,8 @@ extra_css:
 
 extra:
   generator: false
+  version:
+    provider: mike
 
 plugins:
   - search

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ mkdocs-material==9.6.14                  # theme
 mkdocs-mermaid2-plugin==1.2.1            # diagrams
 mkdocs-awesome-pages-plugin==2.10.1      # sidebar ordering
 mkdocs-enumerate-headings-plugin==0.6.2  # auto-number headings
+mike==2.1.3                              # versioned documentation
 codespell==2.4.1                         # spelling linter
 pre-commit                               # precommit


### PR DESCRIPTION
Need this for manual publishing 1.0 docs, the next step is to automate this using release workflow