### PR TITLE
S3CSI-99: release notes and upgrade guide for 1.1.0

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -13,6 +13,8 @@ on:
       - 'mkdocs.yml'
       - 'requirements.txt'  # MkDocs requirements
       - 'NOTICE'
+      - '.lychee.toml'
+      - '.markdownlint.yaml'
 
 env:
   KUBECONFIG: "/home/runner/.kube/config"

--- a/.github/workflows/tests-and-compliance.yaml
+++ b/.github/workflows/tests-and-compliance.yaml
@@ -12,6 +12,8 @@ on:
       - '*.md'
       - 'mkdocs.yml'
       - 'requirements.txt'
+      - '.lychee.toml'
+      - '.markdownlint.yaml'
 
 jobs:
   code-quality-tests:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -78,6 +78,9 @@ exclude = [
     "github\\.com/.*/edit/",
     "github\\.com/.*/blob/.*/.*\\.(md|txt)$",
 
+    # Exclude GitHub release URLs for this repository (allows merging docs before release)
+    "github\\.com/scality/mountpoint-s3-csi-driver/releases/",
+
     # Exclude URLs with placeholders
     "<[^>]+>",
     "\\$\\{[^}]+\\}",

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: scality-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Scality S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
-version: 0.3.0
+version: 1.1.0
 kubeVersion: ">=1.30.0-0"
 home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,10 +33,12 @@ It implements the [CSI specification](https://github.com/container-storage-inter
 Container images for the Scality S3 CSI Driver are hosted on GHCR:
 
 | Driver Version | Image URL                                                                 |
-|----------------|---------------------------------------------------------------------------|
-| 1.0.0          | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                          |
+|---------------|----------------------------------------------------------------------------|
+| 1.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.0`                           |
+| 1.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                           |
 
-*Note: Please check the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for the latest available versions.*
+!!! info
+    Review [release notes](release-notes.md) for breaking changes and the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for complete changelog details.
 
 ## Support and Community
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,10 +35,13 @@ Container images for the Scality S3 CSI Driver are hosted on GHCR:
 | Driver Version | Image URL                                                                 |
 |---------------|----------------------------------------------------------------------------|
 | 1.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.0`                           |
-| 1.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                           |
 
-!!! info
-    Review [release notes](release-notes.md) for breaking changes and the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for complete changelog details.
+Review [release notes](release-notes.md) for breaking changes and the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for complete changelog details.
+
+??? note "Previous Images"
+    | Driver Version | Image URL                                                                 |
+    |---------------|----------------------------------------------------------------------------|
+    | 1.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                           |
 
 ## Support and Community
 

--- a/docs/driver-deployment/upgrade-guide.md
+++ b/docs/driver-deployment/upgrade-guide.md
@@ -93,9 +93,11 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=scality-mountpoint-s3
 
 ## Rollback (If Needed)
 
-If issues occur after upgrade:
+!!! warning
+    If any application pods using the S3 buckets as filesystems are restarted during the rollback they will lose access to the buckets.
+    Once the rollback is complete, the application pods will automatically regain access to the buckets.
 
-**Option A: Helm rollback:**
+If issues occur after upgrade you can rollback to the previous version using the following steps:
 
 ```bash
 # Check rollback history
@@ -103,20 +105,6 @@ helm history scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
 
 # Rollback to previous version
 helm rollback scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
-```
-
-**Option B: Reinstall previous version:**
-
-```bash
-# Uninstall current version
-helm uninstall scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
-
-# Reinstall previous version
-helm install scality-mountpoint-s3-csi-driver \
-  oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version <PREVIOUS_VERSION> \
-  --values values-production.yaml \
-  --namespace ${NAMESPACE}
 ```
 
 ## Troubleshooting

--- a/docs/driver-deployment/upgrade-guide.md
+++ b/docs/driver-deployment/upgrade-guide.md
@@ -1,0 +1,138 @@
+# Upgrade Guide
+
+This guide provides instructions for upgrading the Scality S3 CSI Driver to newer versions.
+
+## Prerequisites
+
+Before upgrading, ensure all requirements outlined in the **[Prerequisites](prerequisites.md)** guide are met for the target version.
+
+## Pre-Upgrade Steps
+
+**Step 1. Set namespace variable:**
+
+Set the namespace where the driver is currently installed:
+
+```bash
+export NAMESPACE="scality-s3-csi"  # Replace with your actual namespace
+```
+
+**Step 2. Check current installation:**
+
+```bash
+# Get current release info
+helm list --all-namespaces | grep scality-mountpoint-s3-csi-driver
+
+# Check current version
+kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=scality-mountpoint-s3-csi-driver -o jsonpath='{.items[0].spec.containers[0].image}'
+```
+
+**Step 3. Review changes:**
+
+Check the [Release Notes](../release-notes.md) for version-specific changes and breaking changes.
+
+**Step 4. Dry run upgrade (recommended):**
+
+```bash
+# Test upgrade without applying changes
+helm upgrade scality-mountpoint-s3-csi-driver \
+  oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
+  --namespace ${NAMESPACE} \
+  --reuse-values \
+  --dry-run
+```
+
+## Upgrade Options
+
+!!! warning
+    If any application pods using the S3 buckets as filesystems are restarted during the upgrade they will lose access to the buckets.
+    Once the upgrade is complete, the application pods will automatically regain access to the buckets.
+
+Choose one of the following upgrade options:
+
+### Option A: Upgrade with Default Values
+
+For installations using existing configuration:
+
+```bash
+helm upgrade scality-mountpoint-s3-csi-driver \
+  oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
+  --namespace ${NAMESPACE} \
+  --reuse-values
+```
+
+### Option B: Upgrade with Custom Values
+
+For installations with custom configuration file:
+
+```bash
+helm upgrade scality-mountpoint-s3-csi-driver \
+  oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
+  --values values-production.yaml \
+  --namespace ${NAMESPACE}
+```
+
+## Post-Upgrade Verification
+
+**Step 1. Check upgrade status:**
+
+```bash
+helm status scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
+```
+
+**Step 2. Verify pods are running:**
+
+```bash
+kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=scality-mountpoint-s3-csi-driver
+```
+
+**Step 3. Check driver version:**
+
+```bash
+kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=scality-mountpoint-s3-csi-driver -o jsonpath='{.items[0].spec.containers[0].image}'
+```
+
+## Rollback (If Needed)
+
+If issues occur after upgrade:
+
+**Option A: Helm rollback:**
+
+```bash
+# Check rollback history
+helm history scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
+
+# Rollback to previous version
+helm rollback scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
+```
+
+**Option B: Reinstall previous version:**
+
+```bash
+# Uninstall current version
+helm uninstall scality-mountpoint-s3-csi-driver -n ${NAMESPACE}
+
+# Reinstall previous version
+helm install scality-mountpoint-s3-csi-driver \
+  oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
+  --version <PREVIOUS_VERSION> \
+  --values values-production.yaml \
+  --namespace ${NAMESPACE}
+```
+
+## Troubleshooting
+
+These are quick checks to verify the upgrade was successful. For detailed troubleshooting, refer to the [troubleshooting guide](../troubleshooting.md).
+
+**Check pod status:**
+
+The driver pod should be in a `Running` state.
+
+```bash
+kubectl describe pods -n ${NAMESPACE} -l app.kubernetes.io/name=scality-mountpoint-s3-csi-driver
+```
+
+**Check CSI driver registration:**
+
+```bash
+kubectl get csidriver s3.csi.scality.com
+```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 ## [1.1.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.1.0)
 
-June 25, 2025
+June 26, 2025
 
 ### What's New
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## [1.1.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.1.0)
+
+June 25, 2025
+
+### What's New
+
+- Enabled `force-path-style` at the driver level to support fully qualified domain names (FQDNs) for RING S3 endpoints.
+
 ## [1.0.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.0.0)
 
 June 13, 2025

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Prerequisites: driver-deployment/prerequisites.md
       - Quick Start: driver-deployment/quick-start.md
       - Installation Guide: driver-deployment/installation-guide.md
+      - Upgrade Guide: driver-deployment/upgrade-guide.md
       - Uninstallation: driver-deployment/uninstallation.md
   - Volume Provisioning:
       - Static Provisioning:


### PR DESCRIPTION
- Added upgrade guide(simple)
- Added Release notes
- Updated lychee filter for non-existant links as we want release notes to be merged before the actual release