### PR TITLE
S3CSI-99: set latest published docs as latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,10 @@ jobs:
           echo "Deploying version ${{ steps.version.outputs.version }} as latest"
           mike deploy ${{ steps.version.outputs.version }} latest --title="${{ steps.version.outputs.version }}" --update-aliases --push
 
+          # Set this version as the default (updates root redirect)
+          echo "Setting ${{ steps.version.outputs.version }} as default"
+          mike set-default ${{ steps.version.outputs.version }} --push --branch=gh-pages
+
       - name: List deployed versions
         run: mike list --branch=gh-pages
 


### PR DESCRIPTION
Thi sis something we could only figure out after trying the release workflow.
We tried it for 1.1.0 and this is the last missing piece
I have fixed it manually for the website
