### PR TITLE
S3CSI-125: add mountpoint debugging flags to all E2E tests

### DIFF
--- a/pkg/mountpoint/args.go
+++ b/pkg/mountpoint/args.go
@@ -21,6 +21,8 @@ const (
 	ArgDirMode                         = "--dir-mode"
 	ArgFileMode                        = "--file-mode"
 	ArgForcePathStyle                  = "--force-path-style"
+	ArgDebug                           = "--debug"
+	ArgDebugCRT                        = "--debug-crt"
 	ArgProfile                         = "--profile"            // stripped – Driver only supports static Keys, profile is for EKS/EC2 environments
 	ArgEndpointURL                     = "--endpoint-url"       // stripped – cluster‑admin controls S3 endpoints
 	ArgStorageClass                    = "--storage-class"      // stripped – driver forces bucket default (STANDARD)

--- a/tests/e2e/customsuites/mountoptions.go
+++ b/tests/e2e/customsuites/mountoptions.go
@@ -18,7 +18,6 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
-	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 )
 
@@ -111,7 +110,6 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 			DefaultNonRootUser,
 			DefaultNonRootGroup,
 			"", // No specific file mode
-			mountpoint.ArgDebug,
 		)
 		l.resources = append(l.resources, resource)
 

--- a/tests/e2e/customsuites/mountoptions.go
+++ b/tests/e2e/customsuites/mountoptions.go
@@ -18,6 +18,7 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 )
 
@@ -110,7 +111,7 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 			DefaultNonRootUser,
 			DefaultNonRootGroup,
 			"", // No specific file mode
-			"debug",
+			mountpoint.ArgDebug,
 		)
 		l.resources = append(l.resources, resource)
 

--- a/tests/e2e/customsuites/util.go
+++ b/tests/e2e/customsuites/util.go
@@ -26,6 +26,8 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 )
 
 /*──────────────────────────────
@@ -295,6 +297,8 @@ func BuildVolumeWithOptions(
 		fmt.Sprintf("uid=%d", uid),
 		fmt.Sprintf("gid=%d", gid),
 		"allow-other",
+		mountpoint.ArgDebug,
+		mountpoint.ArgDebugCRT,
 	}
 	if fileModeOption != "" {
 		opts = append(opts, fmt.Sprintf("file-mode=%s", fileModeOption))

--- a/tests/e2e/customsuites/util.go
+++ b/tests/e2e/customsuites/util.go
@@ -26,8 +26,6 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
-
-	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 )
 
 /*──────────────────────────────
@@ -297,8 +295,8 @@ func BuildVolumeWithOptions(
 		fmt.Sprintf("uid=%d", uid),
 		fmt.Sprintf("gid=%d", gid),
 		"allow-other",
-		mountpoint.ArgDebug,
-		mountpoint.ArgDebugCRT,
+		"debug",
+		"debug-crt",
 	}
 	if fileModeOption != "" {
 		opts = append(opts, fmt.Sprintf("file-mode=%s", fileModeOption))


### PR DESCRIPTION
Add ArgDebug and ArgDebugCRT constants and include them in all E2E tests for enhanced debugging output from mountpoint-s3 binary.