### PR TITLE
(Refactoring to align with upstream) S3CSI-110: refactor mount functions

### DIFF
--- a/pkg/driver/node/mounter/mounter.go
+++ b/pkg/driver/node/mounter/mounter.go
@@ -5,16 +5,10 @@ import (
 	"context"
 	"os"
 
-	"k8s.io/mount-utils"
-
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
-	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/system"
 )
-
-// https://github.com/awslabs/mountpoint-s3/blob/9ed8b6243f4511e2013b2f4303a9197c3ddd4071/mountpoint-s3/src/cli.rs#L421
-const mountpointDeviceName = "mountpoint-s3"
 
 type ServiceRunner interface {
 	StartService(ctx context.Context, config *system.ExecConfig) (string, error)
@@ -39,10 +33,4 @@ func MountS3Path() string {
 		mountS3Path = defaultMountS3Path
 	}
 	return mountS3Path
-}
-
-// isMountPoint returns whether given `target` is a `mount-s3` mount.
-// Deprecated: Use mpmounter.CheckMountpoint instead. This function is kept for backward compatibility.
-func isMountPoint(mounter mount.Interface, target string) (bool, error) {
-	return mpmounter.CheckMountpoint(mounter, target)
 }

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -358,7 +358,7 @@ func (pm *PodMounter) mountSyscallWithDefault(target string, args mountpoint.Arg
 
 // unmountTarget calls `unmount` syscall on `target`.
 func (pm *PodMounter) unmountTarget(target string) error {
-	return pm.mount.Unmount(target)
+	return mpmounter.UnmountTarget(pm.mount, target)
 }
 
 // volumeNameFromTargetPath tries to extract PersistentVolume's name from `target` path.

--- a/pkg/driver/node/mounter/pod_mounter_darwin.go
+++ b/pkg/driver/node/mounter/pod_mounter_darwin.go
@@ -4,15 +4,8 @@ import (
 	"errors"
 
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
-	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 )
 
 func (pm *PodMounter) mountSyscallDefault(_ string, _ mountpoint.Args) (int, error) {
 	return 0, errors.New("Only supported on Linux")
-}
-
-// verifyMountPointStatx verifies that the given path is accessible on Darwin.
-// Deprecated: Use mpmounter.VerifyMountPoint instead. This function is kept for backward compatibility.
-func verifyMountPointStatx(path string) error {
-	return mpmounter.VerifyMountPoint(path)
 }

--- a/pkg/driver/node/mounter/pod_mounter_darwin.go
+++ b/pkg/driver/node/mounter/pod_mounter_darwin.go
@@ -2,17 +2,17 @@ package mounter
 
 import (
 	"errors"
-	"os"
 
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
+	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 )
 
 func (pm *PodMounter) mountSyscallDefault(_ string, _ mountpoint.Args) (int, error) {
 	return 0, errors.New("Only supported on Linux")
 }
 
+// verifyMountPointStatx verifies that the given path is accessible on Darwin.
+// Deprecated: Use mpmounter.VerifyMountPoint instead. This function is kept for backward compatibility.
 func verifyMountPointStatx(path string) error {
-	// statx is a Linux-specific syscall, let's simulate with os.Stat
-	_, err := os.Stat(path)
-	return err
+	return mpmounter.VerifyMountPoint(path)
 }

--- a/pkg/driver/node/mounter/pod_mounter_linux.go
+++ b/pkg/driver/node/mounter/pod_mounter_linux.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"syscall"
 
-	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
+	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 )
 
 // mountSyscallDefault creates a FUSE file descriptor and performs a `mount` syscall with given `target` and mount arguments.
@@ -65,15 +65,8 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 	return fd, nil
 }
 
+// verifyMountPointStatx verifies that the given path is accessible using statx syscall.
+// Deprecated: Use mpmounter.VerifyMountPoint instead. This function is kept for backward compatibility.
 func verifyMountPointStatx(path string) error {
-	var stat unix.Statx_t
-	if err := unix.Statx(unix.AT_FDCWD, path, unix.AT_STATX_FORCE_SYNC, 0, &stat); err != nil {
-		if err == unix.ENOSYS {
-			// statx() syscall is not supported, retry with regular os.Stat
-			_, err = os.Stat(path)
-		}
-		return err
-	}
-
-	return nil
+	return mpmounter.VerifyMountPoint(path)
 }

--- a/pkg/driver/node/mounter/pod_mounter_linux.go
+++ b/pkg/driver/node/mounter/pod_mounter_linux.go
@@ -1,22 +1,16 @@
 package mounter
 
 import (
-	"fmt"
-	"os"
-	"strings"
-	"syscall"
-
-	"k8s.io/klog/v2"
-
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 )
 
 // mountSyscallDefault creates a FUSE file descriptor and performs a `mount` syscall with given `target` and mount arguments.
+// Deprecated: This function uses the new centralized mount operations from pkg/mountpoint/mounter.
 func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (int, error) {
-	fd, err := syscall.Open("/dev/fuse", os.O_RDWR, 0)
+	fd, err := mpmounter.OpenFUSEDevice()
 	if err != nil {
-		return 0, fmt.Errorf("failed to open /dev/fuse: %w", err)
+		return 0, err
 	}
 
 	// This will set false on a success condition and will stay true
@@ -25,48 +19,23 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 	closeFd := true
 	defer func() {
 		if closeFd {
-			pm.closeFUSEDevFD(fd)
+			mpmounter.CloseFUSEDevice(fd)
 		}
 	}()
 
-	var stat syscall.Stat_t
-	err = syscall.Stat(target, &stat)
+	options, err := mpmounter.CreateMountOptions(fd, target, args)
 	if err != nil {
-		return 0, fmt.Errorf("failed to stat mount point %s: %w", target, err)
+		return 0, err
 	}
 
-	options := []string{
-		fmt.Sprintf("fd=%d", fd),
-		fmt.Sprintf("rootmode=%o", stat.Mode&syscall.S_IFMT),
-		fmt.Sprintf("user_id=%d", os.Geteuid()),
-		fmt.Sprintf("group_id=%d", os.Getegid()),
-		"default_permissions",
-	}
+	flags := mpmounter.CreateMountFlags(args)
 
-	flags := uintptr(syscall.MS_NODEV | syscall.MS_NOSUID | syscall.MS_NOATIME)
-
-	if args.Has(mountpoint.ArgReadOnly) {
-		flags |= syscall.MS_RDONLY
-	}
-
-	if args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot) {
-		options = append(options, "allow_other")
-	}
-
-	optionsJoined := strings.Join(options, ",")
-	klog.V(4).Infof("Mounting %s with options %s", target, optionsJoined)
-	err = syscall.Mount(mountpointDeviceName, target, "fuse", flags, optionsJoined)
+	err = mpmounter.PerformMount(target, options, flags)
 	if err != nil {
-		return 0, fmt.Errorf("failed to mount %s: %w", target, err)
+		return 0, err
 	}
 
 	// We successfully performed the mount operation, ensure to not close the FUSE file descriptor.
 	closeFd = false
 	return fd, nil
-}
-
-// verifyMountPointStatx verifies that the given path is accessible using statx syscall.
-// Deprecated: Use mpmounter.VerifyMountPoint instead. This function is kept for backward compatibility.
-func verifyMountPointStatx(path string) error {
-	return mpmounter.VerifyMountPoint(path)
 }

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
+	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/system"
 )
 
@@ -42,7 +43,7 @@ func NewSystemdMounter(credProvider *credentialprovider.Provider, mpVersion stri
 
 // IsMountPoint returns whether given `target` is a `mount-s3` mount.
 func (m *SystemdMounter) IsMountPoint(target string) (bool, error) {
-	return isMountPoint(m.Mounter, target)
+	return mpmounter.CheckMountpoint(m.Mounter, target)
 }
 
 // Mount mounts the given bucket at the target path using provided credentials.
@@ -70,7 +71,7 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 	cleanupDir := false
 
 	// check if the target path exists and is a directory
-	mountpointErr := verifyMountPointStatx(target)
+	mountpointErr := mpmounter.VerifyMountPoint(target)
 	if mountpointErr != nil {
 		// does not exist, create the directory
 		if os.IsNotExist(mountpointErr) {

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -1,0 +1,50 @@
+// Package mounter provides low-level mount operations for Mountpoint S3 CSI driver.
+// This package centralizes mount, unmount, and mount point validation functionality
+// that was previously scattered across different mounter implementations.
+package mounter
+
+import (
+	"fmt"
+
+	"k8s.io/mount-utils"
+)
+
+// Common constants for mount operations will be added as needed
+
+// Common errors for mount operations
+var (
+	// ErrMissingTarget indicates that the mount target path is missing or empty
+	ErrMissingTarget = fmt.Errorf("mount target is missing or empty")
+
+	// ErrTargetNotDirectory indicates that the mount target is not a directory
+	ErrTargetNotDirectory = fmt.Errorf("mount target is not a directory")
+)
+
+// Target represents a mount target path
+type Target = string
+
+// MountOptions represents standardized mount options for Mountpoint operations
+type MountOptions struct {
+	ReadOnly   bool
+	AllowOther bool
+}
+
+// Mounter provides an interface for low-level mount operations.
+// This interface abstracts platform-specific mount implementations.
+type Mounter struct {
+	mountutils mount.Interface
+}
+
+// NewMounter creates a new Mounter instance with the given mount interface.
+func NewMounter(mountInterface mount.Interface) *Mounter {
+	return &Mounter{
+		mountutils: mountInterface,
+	}
+}
+
+// NewDefaultMounter creates a new Mounter instance with the default mount interface.
+func NewDefaultMounter() *Mounter {
+	return NewMounter(mount.New(""))
+}
+
+// Additional utility functions will be added as needed in subsequent commits

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -84,3 +84,8 @@ func CheckMountpoint(mounter mount.Interface, target string) (bool, error) {
 func (m *Mounter) CheckMountpoint(target string) (bool, error) {
 	return CheckMountpoint(m.mountutils, target)
 }
+
+// UnmountTarget performs unmount operation on the given target path.
+func UnmountTarget(mounter mount.Interface, target string) error {
+	return mounter.Unmount(target)
+}

--- a/pkg/mountpoint/mounter/mount_darwin.go
+++ b/pkg/mountpoint/mounter/mount_darwin.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+package mounter
+
+import (
+	"os"
+)
+
+// VerifyMountPoint verifies that the given path is accessible on Darwin.
+// Since statx is a Linux-specific syscall, this implementation uses the standard os.Stat function.
+func VerifyMountPoint(path string) error {
+	// statx is a Linux-specific syscall, use os.Stat on Darwin
+	_, err := os.Stat(path)
+	return err
+}

--- a/pkg/mountpoint/mounter/mount_darwin.go
+++ b/pkg/mountpoint/mounter/mount_darwin.go
@@ -3,7 +3,10 @@
 package mounter
 
 import (
+	"errors"
 	"os"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 )
 
 // VerifyMountPoint verifies that the given path is accessible on Darwin.
@@ -12,4 +15,30 @@ func VerifyMountPoint(path string) error {
 	// statx is a Linux-specific syscall, use os.Stat on Darwin
 	_, err := os.Stat(path)
 	return err
+}
+
+// OpenFUSEDevice returns an error on Darwin as FUSE device operations are not supported.
+func OpenFUSEDevice() (int, error) {
+	return 0, errors.New("FUSE device operations only supported on Linux")
+}
+
+// CloseFUSEDevice is a no-op on Darwin as FUSE device operations are not supported.
+func CloseFUSEDevice(fd int) {
+	// No-op on Darwin
+}
+
+// CreateMountOptions returns an error on Darwin as FUSE mount options are Linux-specific.
+func CreateMountOptions(fd int, target string, args mountpoint.Args) ([]string, error) {
+	return nil, errors.New("FUSE mount options only supported on Linux")
+}
+
+// CreateMountFlags returns an error on Darwin as mount flags are Linux-specific.
+func CreateMountFlags(args mountpoint.Args) uintptr {
+	// Return 0 as mount flags are Linux-specific
+	return 0
+}
+
+// PerformMount returns an error on Darwin as mount syscall is Linux-specific.
+func PerformMount(target string, options []string, flags uintptr) error {
+	return errors.New("mount syscall only supported on Linux")
 }

--- a/pkg/mountpoint/mounter/mount_darwin_test.go
+++ b/pkg/mountpoint/mounter/mount_darwin_test.go
@@ -1,0 +1,97 @@
+//go:build darwin
+
+package mounter
+
+import (
+	"testing"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
+)
+
+func TestVerifyMountPoint_Darwin(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{
+			name:          "existing directory",
+			path:          "/tmp",
+			expectedError: false,
+		},
+		{
+			name:          "non-existing path",
+			path:          "/non/existing/path",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyMountPoint(tt.path)
+			if (err != nil) != tt.expectedError {
+				t.Errorf("VerifyMountPoint() error = %v, expectedError %v", err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestOpenFUSEDevice_Darwin(t *testing.T) {
+	// On Darwin, FUSE operations are not supported
+	_, err := OpenFUSEDevice()
+	if err == nil {
+		t.Error("OpenFUSEDevice() should return an error on Darwin")
+	}
+
+	expectedErrMsg := "FUSE device operations only supported on Linux"
+	if err.Error() != expectedErrMsg {
+		t.Errorf("OpenFUSEDevice() error = %v, expected %v", err, expectedErrMsg)
+	}
+}
+
+func TestCloseFUSEDevice_Darwin(t *testing.T) {
+	// On Darwin, this should be a no-op - just verify it doesn't panic
+	CloseFUSEDevice(0)
+	CloseFUSEDevice(-1)
+	CloseFUSEDevice(999)
+}
+
+func TestCreateMountOptions_Darwin(t *testing.T) {
+	args := mountpoint.ParseArgs([]string{})
+	options, err := CreateMountOptions(0, "/tmp", args)
+
+	if err == nil {
+		t.Error("CreateMountOptions() should return an error on Darwin")
+	}
+
+	if options != nil {
+		t.Error("CreateMountOptions() should return nil options on Darwin")
+	}
+
+	expectedErrMsg := "FUSE mount options only supported on Linux"
+	if err.Error() != expectedErrMsg {
+		t.Errorf("CreateMountOptions() error = %v, expected %v", err, expectedErrMsg)
+	}
+}
+
+func TestCreateMountFlags_Darwin(t *testing.T) {
+	args := mountpoint.ParseArgs([]string{})
+	flags := CreateMountFlags(args)
+
+	if flags != 0 {
+		t.Errorf("CreateMountFlags() = %v, expected 0 on Darwin", flags)
+	}
+}
+
+func TestPerformMount_Darwin(t *testing.T) {
+	err := PerformMount("/tmp", []string{}, 0)
+
+	if err == nil {
+		t.Error("PerformMount() should return an error on Darwin")
+	}
+
+	expectedErrMsg := "mount syscall only supported on Linux"
+	if err.Error() != expectedErrMsg {
+		t.Errorf("PerformMount() error = %v, expected %v", err, expectedErrMsg)
+	}
+}

--- a/pkg/mountpoint/mounter/mount_linux.go
+++ b/pkg/mountpoint/mounter/mount_linux.go
@@ -3,9 +3,15 @@
 package mounter
 
 import (
+	"fmt"
 	"os"
+	"strings"
+	"syscall"
 
 	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
 )
 
 // VerifyMountPoint verifies that the given path is accessible using the statx syscall on Linux.
@@ -19,6 +25,70 @@ func VerifyMountPoint(path string) error {
 			_, err = os.Stat(path)
 		}
 		return err
+	}
+
+	return nil
+}
+
+// OpenFUSEDevice opens /dev/fuse and returns the file descriptor on Linux.
+func OpenFUSEDevice() (int, error) {
+	fd, err := syscall.Open("/dev/fuse", os.O_RDWR, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /dev/fuse: %w", err)
+	}
+	return fd, nil
+}
+
+// CloseFUSEDevice closes the given FUSE file descriptor on Linux.
+func CloseFUSEDevice(fd int) {
+	err := syscall.Close(fd)
+	if err != nil {
+		klog.V(4).Infof("Mount: failed to close /dev/fuse file descriptor %d: %v\n", fd, err)
+	}
+}
+
+// CreateMountOptions creates FUSE mount options from the given file descriptor, target path, and mount arguments on Linux.
+func CreateMountOptions(fd int, target string, args mountpoint.Args) ([]string, error) {
+	var stat syscall.Stat_t
+	err := syscall.Stat(target, &stat)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat mount point %s: %w", target, err)
+	}
+
+	options := []string{
+		fmt.Sprintf("fd=%d", fd),
+		fmt.Sprintf("rootmode=%o", stat.Mode&syscall.S_IFMT),
+		fmt.Sprintf("user_id=%d", os.Geteuid()),
+		fmt.Sprintf("group_id=%d", os.Getegid()),
+		"default_permissions",
+	}
+
+	if args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot) {
+		options = append(options, "allow_other")
+	}
+
+	return options, nil
+}
+
+// CreateMountFlags creates mount flags from the given mount arguments on Linux.
+func CreateMountFlags(args mountpoint.Args) uintptr {
+	flags := uintptr(syscall.MS_NODEV | syscall.MS_NOSUID | syscall.MS_NOATIME)
+
+	if args.Has(mountpoint.ArgReadOnly) {
+		flags |= syscall.MS_RDONLY
+	}
+
+	return flags
+}
+
+// PerformMount performs the actual mount syscall with the given parameters on Linux.
+func PerformMount(target string, options []string, flags uintptr) error {
+	optionsJoined := strings.Join(options, ",")
+	klog.V(4).Infof("Mounting %s with options %s", target, optionsJoined)
+
+	err := syscall.Mount(MountpointDeviceName, target, "fuse", flags, optionsJoined)
+	if err != nil {
+		return fmt.Errorf("failed to mount %s: %w", target, err)
 	}
 
 	return nil

--- a/pkg/mountpoint/mounter/mount_linux.go
+++ b/pkg/mountpoint/mounter/mount_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package mounter
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// VerifyMountPoint verifies that the given path is accessible using the statx syscall on Linux.
+// This function provides enhanced mount point validation with Linux-specific optimizations.
+// It falls back to regular os.Stat if statx is not supported on the system.
+func VerifyMountPoint(path string) error {
+	var stat unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, path, unix.AT_STATX_FORCE_SYNC, 0, &stat); err != nil {
+		if err == unix.ENOSYS {
+			// statx() syscall is not supported, retry with regular os.Stat
+			_, err = os.Stat(path)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/mountpoint/mounter/mount_linux_test.go
+++ b/pkg/mountpoint/mounter/mount_linux_test.go
@@ -1,0 +1,224 @@
+//go:build linux
+
+package mounter
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
+)
+
+func TestVerifyMountPoint(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{
+			name:          "existing directory",
+			path:          "/tmp",
+			expectedError: false,
+		},
+		{
+			name:          "non-existing path",
+			path:          "/non/existing/path",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyMountPoint(tt.path)
+			if (err != nil) != tt.expectedError {
+				t.Errorf("VerifyMountPoint() error = %v, expectedError %v", err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestOpenAndCloseFUSEDevice(t *testing.T) {
+	// Skip if /dev/fuse doesn't exist (common in containers)
+	if _, err := os.Stat("/dev/fuse"); os.IsNotExist(err) {
+		t.Skip("Skipping test because /dev/fuse doesn't exist")
+	}
+
+	fd, err := OpenFUSEDevice()
+	if err != nil {
+		t.Fatalf("OpenFUSEDevice() failed: %v", err)
+	}
+
+	if fd <= 0 {
+		t.Errorf("OpenFUSEDevice() returned invalid fd: %d", fd)
+	}
+
+	CloseFUSEDevice(fd)
+
+	// Verify the fd is actually closed by attempting to use it
+	var stat syscall.Stat_t
+	err = syscall.Fstat(fd, &stat)
+	if err == nil {
+		t.Error("CloseFUSEDevice() did not close the file descriptor")
+	}
+}
+
+func TestCreateMountOptions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "mount_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	tests := []struct {
+		name          string
+		fd            int
+		target        string
+		args          mountpoint.Args
+		expectedError bool
+		expectOptions []string
+	}{
+		{
+			name:          "basic mount options",
+			fd:            3,
+			target:        tmpDir,
+			args:          mountpoint.ParseArgs([]string{}),
+			expectedError: false,
+			expectOptions: []string{"fd=3", "default_permissions"},
+		},
+		{
+			name:          "with allow-other flag",
+			fd:            3,
+			target:        tmpDir,
+			args:          mountpoint.ParseArgs([]string{mountpoint.ArgAllowOther}),
+			expectedError: false,
+			expectOptions: []string{"fd=3", "default_permissions", "allow_other"},
+		},
+		{
+			name:          "with allow-root flag",
+			fd:            3,
+			target:        tmpDir,
+			args:          mountpoint.ParseArgs([]string{mountpoint.ArgAllowRoot}),
+			expectedError: false,
+			expectOptions: []string{"fd=3", "default_permissions", "allow_other"},
+		},
+		{
+			name:          "non-existing target",
+			fd:            3,
+			target:        "/non/existing/path",
+			args:          mountpoint.ParseArgs([]string{}),
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options, err := CreateMountOptions(tt.fd, tt.target, tt.args)
+
+			if (err != nil) != tt.expectedError {
+				t.Errorf("CreateMountOptions() error = %v, expectedError %v", err, tt.expectedError)
+				return
+			}
+
+			if !tt.expectedError {
+				// Check if all expected options are present
+				for _, expectedOption := range tt.expectOptions {
+					found := false
+					for _, option := range options {
+						if option == expectedOption {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("CreateMountOptions() missing expected option: %s, got: %v", expectedOption, options)
+					}
+				}
+
+				// Verify fd option is present and correct
+				found := false
+				for _, option := range options {
+					if option == "fd=3" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("CreateMountOptions() should include fd option, got: %v", options)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateMountFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          mountpoint.Args
+		expectedFlags uintptr
+	}{
+		{
+			name:          "default flags",
+			args:          mountpoint.ParseArgs([]string{}),
+			expectedFlags: syscall.MS_NODEV | syscall.MS_NOSUID | syscall.MS_NOATIME,
+		},
+		{
+			name:          "with read-only flag",
+			args:          mountpoint.ParseArgs([]string{mountpoint.ArgReadOnly}),
+			expectedFlags: syscall.MS_NODEV | syscall.MS_NOSUID | syscall.MS_NOATIME | syscall.MS_RDONLY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := CreateMountFlags(tt.args)
+
+			if flags != tt.expectedFlags {
+				t.Errorf("CreateMountFlags() = %v, expected %v", flags, tt.expectedFlags)
+			}
+		})
+	}
+}
+
+func TestPerformMount(t *testing.T) {
+	// This test cannot perform actual mount operations without root privileges
+	// and appropriate setup, so we'll test the function signature and basic validation
+	tests := []struct {
+		name        string
+		target      string
+		options     []string
+		flags       uintptr
+		expectError bool
+	}{
+		{
+			name:        "basic parameters",
+			target:      "/mnt/test",
+			options:     []string{"fd=3", "default_permissions"},
+			flags:       syscall.MS_NODEV,
+			expectError: true, // Expected to fail due to permissions/setup
+		},
+		{
+			name:        "empty target",
+			target:      "",
+			options:     []string{},
+			flags:       0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := PerformMount(tt.target, tt.options, tt.flags)
+
+			if (err != nil) != tt.expectError {
+				// For permission-related errors, just verify that the function
+				// doesn't panic and returns an error as expected
+				if err != nil && tt.expectError {
+					// This is expected - we can't actually mount without proper setup
+					return
+				}
+				t.Errorf("PerformMount() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}

--- a/pkg/mountpoint/mounter/mount_test.go
+++ b/pkg/mountpoint/mounter/mount_test.go
@@ -1,0 +1,224 @@
+package mounter
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"k8s.io/mount-utils"
+)
+
+// mockMountInterface implements mount.Interface for testing
+type mockMountInterface struct {
+	mountPoints  []mount.MountPoint
+	listError    error
+	unmountError error
+	unmountCalls []string
+}
+
+func (m *mockMountInterface) Mount(source, target, fstype string, options []string) error {
+	return nil
+}
+
+func (m *mockMountInterface) MountSensitive(source, target, fstype string, options, sensitiveOptions []string) error {
+	return nil
+}
+
+func (m *mockMountInterface) MountSensitiveWithoutSystemd(source, target, fstype string, options, sensitiveOptions []string) error {
+	return nil
+}
+
+func (m *mockMountInterface) MountSensitiveWithoutSystemdWithMountFlags(source, target, fstype string, options, sensitiveOptions, mountFlags []string) error {
+	return nil
+}
+
+func (m *mockMountInterface) Unmount(target string) error {
+	m.unmountCalls = append(m.unmountCalls, target)
+	return m.unmountError
+}
+
+func (m *mockMountInterface) List() ([]mount.MountPoint, error) {
+	return m.mountPoints, m.listError
+}
+
+func (m *mockMountInterface) IsMountPoint(file string) (bool, error) {
+	return false, nil
+}
+
+func (m *mockMountInterface) IsLikelyNotMountPoint(file string) (bool, error) {
+	return true, nil
+}
+
+func (m *mockMountInterface) CanSafelySkipMountPointCheck() bool {
+	return false
+}
+
+func (m *mockMountInterface) GetMountRefs(pathname string) ([]string, error) {
+	return []string{}, nil
+}
+
+func TestCheckMountpoint(t *testing.T) {
+	tmpDir1, err := os.MkdirTemp("", "mount_test_1")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir1) }()
+
+	tmpDir2, err := os.MkdirTemp("", "mount_test_2")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir2) }()
+
+	tmpDir3, err := os.MkdirTemp("", "mount_test_3")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir3) }()
+
+	tests := []struct {
+		name           string
+		target         string
+		mountPoints    []mount.MountPoint
+		listError      error
+		expectedResult bool
+		expectedError  bool
+	}{
+		{
+			name:   "target is mountpoint-s3 mount",
+			target: tmpDir1,
+			mountPoints: []mount.MountPoint{
+				{Path: tmpDir1, Device: MountpointDeviceName},
+				{Path: tmpDir2, Device: "tmpfs"},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name:   "target is not mountpoint-s3 mount",
+			target: tmpDir2,
+			mountPoints: []mount.MountPoint{
+				{Path: tmpDir1, Device: MountpointDeviceName},
+				{Path: tmpDir2, Device: "tmpfs"},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name:   "target not found in mount points",
+			target: tmpDir3,
+			mountPoints: []mount.MountPoint{
+				{Path: tmpDir1, Device: MountpointDeviceName},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name:           "list mounts fails",
+			target:         tmpDir1,
+			listError:      errors.New("failed to list mounts"),
+			expectedResult: false,
+			expectedError:  true,
+		},
+		{
+			name:           "empty mount points list",
+			target:         tmpDir1,
+			mountPoints:    []mount.MountPoint{},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name:   "multiple mounts with same path, different devices",
+			target: tmpDir3,
+			mountPoints: []mount.MountPoint{
+				{Path: tmpDir3, Device: "tmpfs"},
+				{Path: tmpDir3, Device: MountpointDeviceName},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name:   "non-existing target path",
+			target: "/non/existing/path",
+			mountPoints: []mount.MountPoint{
+				{Path: "/non/existing/path", Device: MountpointDeviceName},
+			},
+			expectedResult: false,
+			expectedError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMounter := &mockMountInterface{
+				mountPoints: tt.mountPoints,
+				listError:   tt.listError,
+			}
+
+			result, err := CheckMountpoint(mockMounter, tt.target)
+
+			if (err != nil) != tt.expectedError {
+				t.Errorf("CheckMountpoint() error = %v, expectedError %v", err, tt.expectedError)
+				return
+			}
+
+			if result != tt.expectedResult {
+				t.Errorf("CheckMountpoint() = %v, expected %v", result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+func TestUnmountTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		target        string
+		unmountError  error
+		expectedError bool
+	}{
+		{
+			name:          "successful unmount",
+			target:        "/mnt/s3",
+			unmountError:  nil,
+			expectedError: false,
+		},
+		{
+			name:          "unmount fails",
+			target:        "/mnt/s3",
+			unmountError:  errors.New("unmount failed"),
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMounter := &mockMountInterface{
+				unmountError: tt.unmountError,
+			}
+
+			err := UnmountTarget(mockMounter, tt.target)
+
+			if (err != nil) != tt.expectedError {
+				t.Errorf("UnmountTarget() error = %v, expectedError %v", err, tt.expectedError)
+			}
+
+			// Verify the unmount was called with correct target
+			if len(mockMounter.unmountCalls) != 1 || mockMounter.unmountCalls[0] != tt.target {
+				t.Errorf("UnmountTarget() called with %v, expected %v", mockMounter.unmountCalls, []string{tt.target})
+			}
+		})
+	}
+}
+
+func TestConstructors(t *testing.T) {
+	mockInterface := &mockMountInterface{}
+	mounter := NewMounter(mockInterface)
+	if mounter == nil || mounter.mountutils == nil {
+		t.Fatal("NewMounter() failed to create valid mounter")
+	}
+
+	defaultMounter := NewDefaultMounter()
+	if defaultMounter == nil || defaultMounter.mountutils == nil {
+		t.Fatal("NewDefaultMounter() failed to create valid mounter")
+	}
+}


### PR DESCRIPTION
From upstream: https://github.com/awslabs/mountpoint-s3-csi-driver/commit/8677df5
With our touch on tests

We do not use pod_mounter as its completely experimental, in v2 we might change the code completely so I didn't add any unit tests for it.