### PR TITLE
S3CSI-160: add static provisioning flow and credentials management docs and fixup on existing credentials documentation

### DIFF
--- a/docs/architecture/ring-s3-credentials-management.md
+++ b/docs/architecture/ring-s3-credentials-management.md
@@ -51,8 +51,7 @@ Default key names are:
 - `session_token` (optional) for Session Token
 
 !!! Note
-    Use `stringData` (not `data`) because the Scality CSI driver for S3 expects plain text credentials, not base64 encoded values.
-    This does not reduce security - base64 is encoding (not encryption), and both methods store credentials identically in Kubernetes. Secret security is controlled by Kubernetes RBAC permissions.
+    Use `stringData` (not `data`) because the Scality CSI driver for S3 expects plain text credential. Secret security is controlled by Kubernetes RBAC permissions.
 
 ```yaml
 apiVersion: v1

--- a/docs/architecture/ring-s3-credentials-management.md
+++ b/docs/architecture/ring-s3-credentials-management.md
@@ -1,0 +1,171 @@
+# Credentials Architecture
+
+This document details how credentials flow through the Scality CSI Driver for S3, supporting both driver-level (global) and volume-level (per-volume) authentication methods.
+
+<div align="center">
+
+```mermaid
+graph LR
+    subgraph driver["Driver-Level Credentials (Default)"]
+        HelmChart["Helm Chart values.yaml"]
+        DriverSecret["Kubernetes Secret"]
+        DriverEnv["Environment Variables in CSI Container"]
+    end
+
+    subgraph volume["Volume-Level Credentials"]
+        PVSpec["Persistent Volume spec (csi.authenticationSource=secret + csi.nodePublishSecretRef)"]
+        VolumeSecret["Kubernetes Secret (referenced by PV spec)"]
+    end
+
+    CSI["Scality CSI Driver for S3 Node Service"]
+    MP["mount-s3 process per volume"]
+    S3["S3 Storage"]
+
+    HelmChart --> DriverSecret
+    DriverSecret --> DriverEnv
+    DriverEnv -->|"Default credentials for all volumes"| CSI
+
+    PVSpec --> VolumeSecret
+    VolumeSecret -->|"Overrides credentials for this volume"| CSI
+
+    CSI -->|"Selected credentials"| MP
+    MP -->|"Authenticated requests"| S3
+```
+
+</div>
+
+## Credentials Management
+
+There are 2 ways to manage credentials:
+
+1. **Driver-Level Authentication** - Global credentials for all volumes
+2. **Persistent Volume-Level Authentication** - Per-volume credentials (set via Persistent Volume specifications)
+
+For Kubernetes secrets used in both driver-level and volume-level authentication,
+the credentials should be stored using the same key names as specified in the
+[values.yaml](https://github.com/scality/mountpoint-s3-csi-driver/blob/main/charts/scality-mountpoint-s3-csi-driver/values.yaml#L104) file.
+Default key names are:
+
+- `access_key_id` for Access Key ID
+- `secret_access_key` for Secret Access Key
+- `session_token` (optional) for Session Token
+
+!!! Note
+    Use `stringData` (not `data`) because the Scality CSI driver for S3 expects plain text credentials, not base64 encoded values.
+    This does not reduce security - base64 is encoding (not encryption), and both methods store credentials identically in Kubernetes. Secret security is controlled by Kubernetes RBAC permissions.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-credentials # use a different name/namespace for volume specific credentials
+type: Opaque
+stringData:  # Use stringData for plain text values
+  access_key_id: "AKIAXXXXXXXXXXXXXXXXX"
+  secret_access_key: "SECRETXXXXXXXXXXXXXXXXXXXXXXXXX"
+  session_token: "SESSION_TOKEN_IF_NEEDED"  # Optional
+```
+
+### Method 1: Driver-Level Authentication
+
+Credentials configured globally during driver installation. All volumes use these credentials unless overridden.
+
+Step 1: Install with Helm (referencing secret)
+
+```bash
+helm install scality-s3-csi-driver charts/scality-mountpoint-s3-csi-driver \
+  --set node.s3EndpointUrl="https://s3.example.com:8000" \
+  --set s3CredentialSecret.name=s3-credentials
+```
+
+Step 2: Create PersistentVolume (no credentials needed)
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3-volume-driver-auth
+spec:
+  capacity:
+    storage: 1200Gi
+  accessModes:
+    - ReadWriteMany
+  csi:
+    driver: s3.csi.scality.com
+    volumeHandle: my-bucket-driver
+    volumeAttributes:
+      bucketName: my-bucket
+      region: us-east-1
+      # No authenticationSource - uses driver-level credentials
+```
+
+### Method 2: Volume-Level Authentication
+
+Each persistent volume can use different credentials stored in Kubernetes Secrets. The secret definition is similar to the driver-level authentication secret.
+For volume-level authentication, the secret is referenced in the PersistentVolume spec via the `nodePublishSecretRef` field and the `authenticationSource` field is set to `secret`.
+This overrides the driver-level credentials for this volume.
+
+**PersistentVolume**:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3-volume-secret
+spec:
+  capacity:
+    storage: 1200Gi
+  accessModes:
+    - ReadWriteMany
+  csi:
+    driver: s3.csi.scality.com
+    volumeHandle: my-bucket-secret
+    volumeAttributes:
+      bucketName: my-bucket
+      region: us-east-1
+      authenticationSource: secret  # Required
+    nodePublishSecretRef:
+      name: s3-credentials # Required
+      namespace: default # Required
+```
+
+## Credential Priority Chain
+
+The Scality CSI driver for S3 evaluates credentials in the following order, using the first valid credentials found:
+
+### Persistent Volume-Level Credentials (Priority 1 - Highest)
+
+- Specified in PersistentVolume spec via `csi.authenticationSource: secret` and `csi.nodePublishSecretRef`
+- Allows different credentials per persistent volume
+- Overrides driver-level settings
+- Use case: Multi-tenant environments
+- Example: [Secret Authentication](../volume-provisioning/static-provisioning/examples/secret-authentication.md)
+
+### Driver-Level Secret (Priority 2)
+
+- Configured in Helm chart values.yaml file
+- Applies to all volumes unless overridden
+- Stored in driver namespace
+- Use case: Single-tenant clusters
+
+## Common Patterns for multi-tenant environments
+
+### Single-Tenant Pattern (Driver-Level)
+
+One set of shared credentials for all volumes. This is the default pattern for single-tenant environments.
+
+```text
+Persistent Volume 1: No secret in PV spec → Driver-level credentials
+Persistent Volume 2: No secret in PV spec → Driver-level credentials
+PersistentVolume 3: No secret in PV spec → Driver-level credentials
+```
+
+### Multi-Tenant Pattern (Volume-Level)
+
+Different credentials per tenant/application. This is the default pattern for multi-tenant environments.
+
+```text
+Persistent Volume 1: Tenant A secret in PV spec → Tenant A's S3 bucket
+Persistent Volume 2: Tenant B secret in PV spec → Tenant B's S3 bucket
+Persistent Volume 3: No secret in PV spec → Driver-level credentials
+```

--- a/docs/architecture/ring-s3-credentials-management.md
+++ b/docs/architecture/ring-s3-credentials-management.md
@@ -53,7 +53,7 @@ Default key names are:
 !!! Note
     Use `stringData` (not `data`) because the Scality CSI driver for S3 expects plain text credential. Secret security is controlled by Kubernetes RBAC permissions.
 
-```yaml
+```yaml title="Kubernetes Secret with RING S3 credentials"
 apiVersion: v1
 kind: Secret
 metadata:
@@ -69,17 +69,13 @@ stringData:  # Use stringData for plain text values
 
 Credentials configured globally during driver installation. All volumes use these credentials unless overridden.
 
-Step 1: Install with Helm (referencing secret)
-
-```bash
+```bash title="Step 1: Install with Helm (referencing secret)"
 helm install scality-s3-csi-driver charts/scality-mountpoint-s3-csi-driver \
   --set node.s3EndpointUrl="https://s3.example.com:8000" \
   --set s3CredentialSecret.name=s3-credentials
 ```
 
-Step 2: Create PersistentVolume (no credentials needed)
-
-```yaml
+```yaml title="Step 2: Create PersistentVolume (no credentials needed)"
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -104,9 +100,7 @@ Each persistent volume can use different credentials stored in Kubernetes Secret
 For volume-level authentication, the secret is referenced in the PersistentVolume spec via the `nodePublishSecretRef` field and the `authenticationSource` field is set to `secret`.
 This overrides the driver-level credentials for this volume.
 
-**PersistentVolume**:
-
-```yaml
+```yaml title="PersistentVolume"
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -149,21 +143,17 @@ The Scality CSI driver for S3 evaluates credentials in the following order, usin
 
 ## Common Patterns for multi-tenant environments
 
-### Single-Tenant Pattern (Driver-Level)
-
 One set of shared credentials for all volumes. This is the default pattern for single-tenant environments.
 
-```text
+```text title="Single-Tenant Pattern (Driver-Level)"
 Persistent Volume 1: No secret in PV spec → Driver-level credentials
 Persistent Volume 2: No secret in PV spec → Driver-level credentials
 PersistentVolume 3: No secret in PV spec → Driver-level credentials
 ```
 
-### Multi-Tenant Pattern (Volume-Level)
-
 Different credentials per tenant/application. This is the default pattern for multi-tenant environments.
 
-```text
+```text title="Multi-Tenant Pattern (Volume-Level)"
 Persistent Volume 1: Tenant A secret in PV spec → Tenant A's S3 bucket
 Persistent Volume 2: Tenant B secret in PV spec → Tenant B's S3 bucket
 Persistent Volume 3: No secret in PV spec → Driver-level credentials

--- a/docs/architecture/static-provisioning-flow.md
+++ b/docs/architecture/static-provisioning-flow.md
@@ -1,0 +1,103 @@
+# Static Provisioning Architecture
+
+This document details the complete lifecycle of statically provisioned volumes in the Scality CSI Driver for S3, from PersistentVolume creation to application file access.
+
+<div align="center">
+
+```mermaid
+sequenceDiagram
+    participant Admin as Kubernetes Administrator
+    participant K8s as Kubernetes API Server
+    participant Dev as Kubernetes Developer
+    participant Kubelet as Kubelet (Node Agent)
+    participant CSI as CSI Driver Node Service
+    participant Systemd as systemd Host Service Manager
+    participant Mount as mount-s3 FUSE Process
+    participant S3 as RING S3 endpoint
+    participant App as Application Pod
+
+    %% Volume Creation Phase
+    note over Admin,K8s: === Volume Creation Phase ===
+    Admin->>K8s: Create PersistentVolume with pre-existing S3 bucket details
+    K8s->>K8s: Validate PV spec
+    K8s->>K8s: Store PV object (PV status: Available)
+
+    %% Claim Binding Phase
+    note over Dev,K8s: === Claim Binding Phase ===
+    Dev->>K8s: Create PersistentVolumeClaim
+    K8s->>K8s: Find matching PV
+    K8s->>K8s: Bind PV and PVC (both become Bound simultaneously)
+    K8s-->>Dev: PVC Bound (Reserved)
+
+    %% Pod Scheduling Phase
+    note over Dev,Kubelet: === Pod Scheduling Phase ===
+    Dev->>K8s: Create Pod with PVC
+    K8s->>K8s: Schedule Pod to Node
+    K8s->>Kubelet: Pod assignment
+
+    %% Volume Mount Phase
+    note over Kubelet,Mount: === Volume Mount Phase (Reactive) ===
+    Kubelet->>CSI: NodePublishVolume RPC (triggered by pod start request)
+    CSI->>CSI: Validate request
+    CSI->>CSI: Prepare mount command
+    CSI->>Systemd: Create transient service via D-Bus
+    Systemd->>Mount: Start mount-s3 process
+    Mount->>S3: Authenticate & connect
+    S3-->>Mount: Connection established
+    Mount->>Mount: Create FUSE mount
+    Mount-->>Systemd: Service active
+    Systemd-->>CSI: Mount successful
+    CSI-->>Kubelet: Volume mounted & ready (FUSE filesystem accessible)
+
+    %% Application Access Phase
+    note over Kubelet,App: === Application Access Phase ===
+    Kubelet->>App: Start application container (volume accessible at mount path)
+    App->>Mount: Supported file operations
+    Mount->>S3: S3 API calls
+    S3-->>Mount: Data transfer
+    Mount-->>App: Folder (prefix) and File (object) data
+
+    %% Cleanup Phase
+    note over K8s,Mount: === Cleanup Phase (Pod Deletion) ===
+    note right of S3: S3 bucket remains unchanged regardless of PV reclaim policy
+    Dev->>K8s: Delete Pod
+    K8s->>Kubelet: Terminate Pod
+    Kubelet->>App: Stop container
+    Kubelet->>CSI: NodeUnpublishVolume RPC
+    CSI->>Systemd: Stop service
+    Systemd->>Mount: Terminate process
+    Mount->>Mount: Unmount filesystem
+    Mount-->>Systemd: Process stopped
+    Systemd-->>CSI: Service removed
+    CSI-->>Kubelet: Volume unmounted
+```
+
+</div>
+
+## Phase Flow Summary
+
+| Phase/Step | Description | Key Outcome |
+|------------|-------------|-------------|
+| **Phase 1: Volume Creation** | **Kubernetes administrator sets up S3 storage reference** | **PV ready for use** |
+| 1.1 | Create PV with S3 bucket name (bucket must pre-exist), mount options, access modes (ReadWriteMany), and optional credentials secret (see [credentials docs](ring-s3-credentials-management.md)) | PV object created |
+| 1.2 | Kubernetes API validates CSI driver name, volumeAttributes, and stores PV in etcd | PV status: Available, waiting for PVC |
+| **Phase 2: Claim Binding** | **Kubernetes developer requests and reserves storage (control plane operation)** | **PV-PVC bound together** |
+| 2.1 | Create PVC with matching storage class (""), access modes, and capacity - must reference specific PV by name | PVC object created (status: Pending) |
+| 2.2 | Kubernetes controller finds matching PV and atomically binds: sets PV.claimRef and PVC.volumeName | Both PV and PVC status: Bound simultaneously - volume reserved but NOT accessible yet |
+| **Phase 3: Pod Scheduling** | **Kubernetes finds where to run the pod** | **Pod assigned to node** |
+| 3.1 | Create Pod with volumeMounts section referencing PVC and specifying container mount path (e.g., /data) | Pod object created (status: Pending) |
+| 3.2 | Scheduler evaluates nodes based on resources, PV node affinity constraints, and CSI driver availability | Pod scheduled to specific node |
+| | | |
+| **Phase 4: Volume Mount (CSI)** | **Node makes S3 bucket accessible as filesystem (physical node operation)** | **S3 mounted locally** |
+| 4.1 | Kubelet triggers NodePublishVolume RPC only when pod starts - reactive process, can happen hours after binding | CSI mount request initiated |
+| 4.2 | CSI driver validates request, extracts S3 credentials, and creates systemd transient service via D-Bus | mount-s3 process started with S3 config |
+| 4.3 | mount-s3 authenticates to S3 endpoint, creates FUSE mount at CSI target path on host node | Volume NOW accessible - FUSE filesystem ready |
+| | | |
+| **Phase 5: Application Access** | **Pod performs file-like operations with S3 limitations** | **S3 data accessible** |
+| 5.1 | Kubelet bind-mounts CSI target path into container at specified mountPath, then starts container | Container running with S3 accessible at /data |
+| 5.2 | Application performs supported file operations (read, sequential write, list), mount-s3 translates to S3 API | S3 bucket access with filesystem semantics |
+| | | |
+| **Phase 6: Cleanup (Pod Deletion)** | **Unmount volume and clean up resources** | **S3 data preserved** |
+| 6.1 | Pod deletion initiated, kubelet stops container with grace period (default 30s), sends SIGTERM then SIGKILL | Container terminated gracefully |
+| 6.2 | Kubelet calls NodeUnpublishVolume RPC, CSI driver stops systemd service and unmounts FUSE filesystem | Volume unmounted, mount-s3 process ended |
+| 6.3 | S3 bucket and all data remain unchanged - static provisioning never deletes buckets regardless of reclaim policy | Original S3 storage completely preserved |

--- a/docs/volume-provisioning/static-provisioning/examples/assets/secret_authentication.yaml
+++ b/docs/volume-provisioning/static-provisioning/examples/assets/secret_authentication.yaml
@@ -11,12 +11,10 @@ metadata:
   name: s3-credentials
   namespace: default
 type: Opaque
-data:
-  # Using base64 encoded values. Example:
-  # echo -n "ACCESS_KEY_ID" | base64
-  access_key_id: QUtJQVhYWFhYWFhYWFhYWFhY
-  # echo -n "SECRET_ACCESS_KEY" | base64
-  secret_access_key: U0VDUkVUWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWA==
+stringData:
+  # Using plain text values - CSI driver expects non-base64 encoded credentials
+  access_key_id: "AKIAXXXXXXXXXXXXXXXXX"
+  secret_access_key: "SECRETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
   # You can also create the secret using kubectl:
   # kubectl create secret generic s3-credentials \

--- a/docs/volume-provisioning/static-provisioning/examples/assets/secret_authentication.yaml
+++ b/docs/volume-provisioning/static-provisioning/examples/assets/secret_authentication.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: default
 type: Opaque
 stringData:
-  # Using plain text values - CSI driver expects non-base64 encoded credentials
+  # Using plain text values
   access_key_id: "AKIAXXXXXXXXXXXXXXXXX"
   secret_access_key: "SECRETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 

--- a/docs/volume-provisioning/static-provisioning/examples/secret-authentication.md
+++ b/docs/volume-provisioning/static-provisioning/examples/secret-authentication.md
@@ -26,7 +26,7 @@ metadata:
   namespace: default
 type: Opaque
 stringData:
-  # Using plain text values - CSI driver expects non-base64 encoded credentials
+  # Using plain text values
   access_key_id: "AKIAXXXXXXXXXXXXXXXXX"
   secret_access_key: "SECRETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 

--- a/docs/volume-provisioning/static-provisioning/examples/secret-authentication.md
+++ b/docs/volume-provisioning/static-provisioning/examples/secret-authentication.md
@@ -25,12 +25,10 @@ metadata:
   name: s3-credentials
   namespace: default
 type: Opaque
-data:
-  # Using base64 encoded values. Example:
-  # echo -n "ACCESS_KEY_ID" | base64
-  access_key_id: QUtJQVhYWFhYWFhYWFhYWFhY
-  # echo -n "SECRET_ACCESS_KEY" | base64
-  secret_access_key: U0VDUkVUWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWA==
+stringData:
+  # Using plain text values - CSI driver expects non-base64 encoded credentials
+  access_key_id: "AKIAXXXXXXXXXXXXXXXXX"
+  secret_access_key: "SECRETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
   # You can also create the secret using kubectl:
   # kubectl create secret generic s3-credentials \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
   - Architecture:
       - System Overview: architecture/system-overview.md
       - Deployment Architecture: architecture/deployment-architecture.md
+      - Static Provisioning Flow: architecture/static-provisioning-flow.md
       - RING S3 Credential management: architecture/ring-s3-credentials-management.md
   - Driver Deployment:
       - Prerequisites: driver-deployment/prerequisites.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
   - Architecture:
       - System Overview: architecture/system-overview.md
       - Deployment Architecture: architecture/deployment-architecture.md
+      - RING S3 Credential management: architecture/ring-s3-credentials-management.md
   - Driver Deployment:
       - Prerequisites: driver-deployment/prerequisites.md
       - Quick Start: driver-deployment/quick-start.md


### PR DESCRIPTION
- Adds Credentials management and Static provisioning documentation
- Remove base64 references from existing documentation as we support only `stringData`