### PR TITLE
S3CSI-161: updates for  v1.1.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,15 @@ jobs:
           # The version identifier and title both use major.minor format (e.g., "1.1")
           # This ensures URLs like /1.1/ and dropdown shows "1.1" not "1.1.1"
           echo "Deploying version ${{ steps.version.outputs.version }} as latest"
-          mike deploy ${{ steps.version.outputs.version }} latest --title="${{ steps.version.outputs.version }}" --update-aliases --push
+
+          # Check if version already exists to avoid duplicate error
+          if mike list --branch=gh-pages | grep -q "^${{ steps.version.outputs.version }}"; then
+            echo "Version ${{ steps.version.outputs.version }} already exists, updating it"
+            mike deploy ${{ steps.version.outputs.version }} latest --title="${{ steps.version.outputs.version }}" --update-aliases --push
+          else
+            echo "Creating new version ${{ steps.version.outputs.version }}"
+            mike deploy ${{ steps.version.outputs.version }} latest --title="${{ steps.version.outputs.version }}" --update-aliases --push
+          fi
 
           # Set this version as the default (updates root redirect)
           echo "Setting ${{ steps.version.outputs.version }} as default"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=1.1.0
+VERSION=1.1.1
 
 # List of allowed licenses in the CSI Driver's dependencies.
 # See https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28 for list of canonical names for licenses.

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: scality-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Scality CSI Driver for S3. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
-version: 1.1.0
+version: 1.1.1
 kubeVersion: ">=1.30.0-0"
 home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/scality/mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.1.0"
+  tag: "1.1.1"
 
 # Node plugin configuration (DaemonSet)
 node:

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Review [release notes](release-notes.md) for breaking changes and the [releases 
     | Driver Version | Image URL                                                                 |
     |---------------|----------------------------------------------------------------------------|
     | 1.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.0`                           |
+    | 1.0.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.1`                           |
     | 1.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                           |
 
 ## Support and Community

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Scality Container Storage Interface S3 Driver Documentation
+# Scality Container Storage Interface Driver for S3 Documentation
 
-The Scality S3 Container Storage Interface (CSI) Driver allows Kubernetes applications to access Scality S3 objects through a file system interface.
+The Scality Container Storage Interface (CSI) Driver for S3 allows Kubernetes applications to access Scality S3 objects through a file system interface.
 This driver is a fork of the [Mountpoint for Amazon S3 CSI Driver](https://github.com/awslabs/mountpoint-s3-csi-driver).
 It has been engineered and optimized specifically for use with Scality S3-compatible storage solutions.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,13 +34,14 @@ Container images for the Scality CSI Driver for S3 are hosted on GHCR:
 
 | Driver Version | Image URL                                                                 |
 |---------------|----------------------------------------------------------------------------|
-| 1.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.0`                           |
+| 1.1.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.1`                           |
 
 Review [release notes](release-notes.md) for breaking changes and the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for complete changelog details.
 
 ??? note "Previous Images"
     | Driver Version | Image URL                                                                 |
     |---------------|----------------------------------------------------------------------------|
+    | 1.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.0`                           |
     | 1.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                           |
 
 ## Support and Community

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## [1.1.1](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.1.1)
+
+August 4, 2025
+
+### What's New
+
+- **Product Name Update**: Renamed from "Scality S3 CSI Driver" to "Scality CSI Driver for S3" per AWS legal requirements.
+- **Enhanced Documentation**: Added comprehensive architecture documentation including:
+  - System overview and deployment architecture diagrams
+  - Static provisioning flow documentation with detailed workflows
+  - S3 credentials management architecture and best practices
+
+### Bug Fixes
+
+- **SystemD D-Bus Reliability**: Fixed D-Bus connection recreation for improved SystemD mount reliability and error handling.
+- **Documentation Improvements**: Remove base64 mention from credentials in kubernetes secrets as the CSI driver does not use it.
+
 ## [1.1.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.1.0)
 
 June 26, 2025

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 ## [1.1.1](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.1.1)
 
-August 4, 2025
+August 5, 2025
 
 ### What's New
 
@@ -24,6 +24,15 @@ June 26, 2025
 ### What's New
 
 - Enabled `force-path-style` at the driver level to support fully qualified domain names (FQDNs) for RING S3 endpoints.
+
+## [1.0.1](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.0.1)
+
+August 5, 2025
+
+### What's Changed
+
+- Documentation update: Renamed from "Scality S3 CSI Driver" to "Scality CSI Driver for S3" to comply with AWS copyright policies.
+- No functional changes to the service or driver behavior.
 
 ## [1.0.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.0.0)
 


### PR DESCRIPTION
Add updates for v1.1.1 and update release notes
This will be merged after https://github.com/scality/mountpoint-s3-csi-driver/pull/151 so I will update the 1.0.1 context in Readme and release notes before merging.