### PR TITLE
feat(controller): add credential provider for dynamic provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION=1.1.1
 
 # List of allowed licenses in the CSI Driver's dependencies.
 # See https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28 for list of canonical names for licenses.
-ALLOWED_LICENSES="Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT"
+ALLOWED_LICENSES="Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT,MPL-2.0"
 
 PKG=github.com/scality/mountpoint-s3-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.6
 	github.com/aws/aws-sdk-go-v2/config v1.29.18
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.71
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/golang/mock v1.6.0
@@ -24,7 +25,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.71 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37 // indirect

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	golang.org/x/net v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWU
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,27 @@
+// Package constants provides common constants for the Scality S3 CSI driver.
+// This includes AWS credential fields, CSI specification parameters, and volume context keys.
+package constants
+
+const (
+	// Secret field names for AWS credentials as expected in Kubernetes secrets
+	// These match the format used by the existing node credential provider
+	AccessKeyIDField     = "access_key_id"
+	SecretAccessKeyField = "secret_access_key"
+	SessionTokenField    = "session_token"
+	RegionField          = "region"
+
+	// CSI standard provisioner secret parameters (for controller operations)
+	// These are defined by the CSI specification and used in StorageClass parameters
+	ProvisionerSecretNameKey      = "csi.storage.k8s.io/provisioner-secret-name"
+	ProvisionerSecretNamespaceKey = "csi.storage.k8s.io/provisioner-secret-namespace"
+
+	// CSI standard node publish secret parameters (for node operations)
+	// These are defined by the CSI specification and used in StorageClass parameters
+	NodePublishSecretNameKey      = "csi.storage.k8s.io/node-publish-secret-name"
+	NodePublishSecretNamespaceKey = "csi.storage.k8s.io/node-publish-secret-namespace"
+
+	// Volume context keys for storing credential metadata
+	// Used to pass credential information from controller to node
+	VolumeContextProvisionerSecretNameKey      = "provisioner-secret-name"
+	VolumeContextProvisionerSecretNamespaceKey = "provisioner-secret-namespace"
+)

--- a/pkg/constants/constants_test.go
+++ b/pkg/constants/constants_test.go
@@ -1,0 +1,75 @@
+package constants
+
+import (
+	"testing"
+)
+
+func TestCredentialConstants(t *testing.T) {
+	// Test AWS credential field names match expected format
+	expectedFields := map[string]string{
+		AccessKeyIDField:     "access_key_id",
+		SecretAccessKeyField: "secret_access_key",
+		SessionTokenField:    "session_token",
+		RegionField:          "region",
+	}
+
+	for constant, expected := range expectedFields {
+		if constant != expected {
+			t.Errorf("Expected credential field constant %q, got %q", expected, constant)
+		}
+	}
+}
+
+func TestCSISecretParameterConstants(t *testing.T) {
+	// Test CSI secret parameter names match CSI specification format
+	expectedParams := map[string]string{
+		ProvisionerSecretNameKey:      "csi.storage.k8s.io/provisioner-secret-name",
+		ProvisionerSecretNamespaceKey: "csi.storage.k8s.io/provisioner-secret-namespace",
+		NodePublishSecretNameKey:      "csi.storage.k8s.io/node-publish-secret-name",
+		NodePublishSecretNamespaceKey: "csi.storage.k8s.io/node-publish-secret-namespace",
+	}
+
+	for constant, expected := range expectedParams {
+		if constant != expected {
+			t.Errorf("Expected CSI parameter constant %q, got %q", expected, constant)
+		}
+	}
+}
+
+func TestVolumeContextConstants(t *testing.T) {
+	// Test volume context key names match expected format
+	expectedKeys := map[string]string{
+		VolumeContextProvisionerSecretNameKey:      "provisioner-secret-name",
+		VolumeContextProvisionerSecretNamespaceKey: "provisioner-secret-namespace",
+	}
+
+	for constant, expected := range expectedKeys {
+		if constant != expected {
+			t.Errorf("Expected volume context constant %q, got %q", expected, constant)
+		}
+	}
+}
+
+func TestConstantUniqueness(t *testing.T) {
+	// Ensure all constants are unique
+	constants := []string{
+		AccessKeyIDField,
+		SecretAccessKeyField,
+		SessionTokenField,
+		RegionField,
+		ProvisionerSecretNameKey,
+		ProvisionerSecretNamespaceKey,
+		NodePublishSecretNameKey,
+		NodePublishSecretNamespaceKey,
+		VolumeContextProvisionerSecretNameKey,
+		VolumeContextProvisionerSecretNamespaceKey,
+	}
+
+	seen := make(map[string]bool)
+	for _, constant := range constants {
+		if seen[constant] {
+			t.Errorf("Duplicate constant value found: %q", constant)
+		}
+		seen[constant] = true
+	}
+}

--- a/pkg/driver/controller/credentialprovider/provider.go
+++ b/pkg/driver/controller/credentialprovider/provider.go
@@ -22,6 +22,9 @@ import (
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/storageclass"
 )
 
+// defaultCredentialCacheTTL is the default TTL for credential cache entries.
+const defaultCredentialCacheTTL = 5 * time.Minute
+
 // CredentialCacheEntry represents a cached credential with expiration
 type CredentialCacheEntry struct {
 	Config    aws.Config
@@ -41,7 +44,7 @@ type Provider struct {
 
 // New creates a new controller credential provider
 func New(client kubernetes.Interface) *Provider {
-	ttl := 5 * time.Minute
+	ttl := defaultCredentialCacheTTL
 	lruCache := expirable.NewLRU[string, aws.Config](512, nil, ttl)
 	return &Provider{
 		client:   client,

--- a/pkg/driver/controller/credentialprovider/provider.go
+++ b/pkg/driver/controller/credentialprovider/provider.go
@@ -1,0 +1,289 @@
+// Package credentialprovider provides credential resolution for controller operations with granular credential handling.
+// This package adapts the existing credential provider patterns for CSI controller use cases,
+// supporting driver-level credentials, provisioner secrets, and node-publish secrets with independent fallback logic.
+package credentialprovider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/storageclass"
+)
+
+// CredentialCacheEntry represents a cached credential with expiration
+type CredentialCacheEntry struct {
+	Config    aws.Config
+	ExpiresAt time.Time
+}
+
+// Provider provides credential resolution for controller operations with granular credential handling
+type Provider struct {
+	client kubernetes.Interface
+
+	// Credential cache for performance optimization and Kubernetes API rate limiting
+	credentialCache map[string]*CredentialCacheEntry
+	cacheMutex      sync.RWMutex
+
+	// Cache TTL for credential validation results
+	cacheTTL time.Duration
+}
+
+// New creates a new controller credential provider
+func New(client kubernetes.Interface) *Provider {
+	return &Provider{
+		client:          client,
+		credentialCache: make(map[string]*CredentialCacheEntry),
+		cacheTTL:        5 * time.Minute, // Default cache TTL
+	}
+}
+
+// NewWithCacheTTL creates a new controller credential provider with custom cache TTL
+func NewWithCacheTTL(client kubernetes.Interface, cacheTTL time.Duration) *Provider {
+	return &Provider{
+		client:          client,
+		credentialCache: make(map[string]*CredentialCacheEntry),
+		cacheTTL:        cacheTTL,
+	}
+}
+
+// ProvideForCreateVolume resolves controller credentials for CreateVolume operations
+// Uses provisioner secret if available, otherwise falls back to driver credentials
+func (p *Provider) ProvideForCreateVolume(ctx context.Context, parameters *storageclass.Parameters) (aws.Config, error) {
+	if parameters.HasProvisionerSecret() {
+		name, namespace := parameters.GetProvisionerSecretRef()
+		klog.V(4).InfoS("Using provisioner secret for CreateVolume", "secretName", name, "secretNamespace", namespace)
+		return p.getSecretCredentials(ctx, name, namespace)
+	}
+
+	klog.V(4).InfoS("Using driver credentials for CreateVolume")
+	return p.getDriverCredentials(ctx)
+}
+
+// ProvideForDeleteVolume resolves controller credentials for DeleteVolume operations
+// Retrieves credentials based on volume context metadata
+func (p *Provider) ProvideForDeleteVolume(ctx context.Context, volumeContext map[string]string) (aws.Config, error) {
+	// Check if volume was created with provisioner secret
+	if secretName := volumeContext[constants.VolumeContextProvisionerSecretNameKey]; secretName != "" {
+		secretNamespace := volumeContext[constants.VolumeContextProvisionerSecretNamespaceKey]
+		if secretNamespace == "" {
+			return aws.Config{}, fmt.Errorf("volume context has provisioner secret name but missing namespace")
+		}
+		klog.V(4).InfoS("Using provisioner secret for DeleteVolume", "secretName", secretName, "secretNamespace", secretNamespace)
+		return p.getSecretCredentials(ctx, secretName, secretNamespace)
+	}
+
+	klog.V(4).InfoS("Using driver credentials for DeleteVolume")
+	return p.getDriverCredentials(ctx)
+}
+
+// ProvideForNodePublish resolves node credentials for NodePublishVolume operations
+// Uses node-publish secret if available, otherwise falls back to driver credentials
+func (p *Provider) ProvideForNodePublish(ctx context.Context, parameters *storageclass.Parameters) (aws.Config, error) {
+	if parameters.HasNodePublishSecret() {
+		name, namespace := parameters.GetNodePublishSecretRef()
+		klog.V(4).InfoS("Using node-publish secret for NodePublish", "secretName", name, "secretNamespace", namespace)
+		return p.getSecretCredentials(ctx, name, namespace)
+	}
+
+	klog.V(4).InfoS("Using driver credentials for NodePublish")
+	return p.getDriverCredentials(ctx)
+}
+
+// GetCredentialsFor provides generic credential resolution for any operation
+func (p *Provider) GetCredentialsFor(ctx context.Context, operation string, parameters *storageclass.Parameters) (aws.Config, error) {
+	switch operation {
+	case "CreateVolume", "controller":
+		return p.ProvideForCreateVolume(ctx, parameters)
+	case "NodePublishVolume", "node":
+		return p.ProvideForNodePublish(ctx, parameters)
+	default:
+		return aws.Config{}, fmt.Errorf("unsupported operation %q for credential resolution", operation)
+	}
+}
+
+// getSecretCredentials retrieves AWS credentials from a Kubernetes secret with caching
+func (p *Provider) getSecretCredentials(ctx context.Context, secretName, secretNamespace string) (aws.Config, error) {
+	cacheKey := fmt.Sprintf("%s/%s", secretNamespace, secretName)
+
+	// Check cache first
+	p.cacheMutex.RLock()
+	if entry, exists := p.credentialCache[cacheKey]; exists && time.Now().Before(entry.ExpiresAt) {
+		p.cacheMutex.RUnlock()
+		klog.V(5).InfoS("Using cached credentials", "secretName", secretName, "secretNamespace", secretNamespace)
+		return entry.Config, nil
+	}
+	p.cacheMutex.RUnlock()
+
+	// Retrieve secret from Kubernetes API
+	secret, err := p.client.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to retrieve secret %s/%s: %w", secretNamespace, secretName, err)
+	}
+
+	// Validate secret contains required AWS credential fields
+	if err := p.ValidateSecretCredentials(secret); err != nil {
+		return aws.Config{}, fmt.Errorf("invalid credentials in secret %s/%s: %w", secretNamespace, secretName, err)
+	}
+
+	// Create AWS config from secret data
+	awsConfig, err := p.CreateAWSConfigFromSecret(secret)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to create AWS config from secret %s/%s: %w", secretNamespace, secretName, err)
+	}
+
+	// Cache the credentials
+	p.cacheMutex.Lock()
+	p.credentialCache[cacheKey] = &CredentialCacheEntry{
+		Config:    awsConfig,
+		ExpiresAt: time.Now().Add(p.cacheTTL),
+	}
+	p.cacheMutex.Unlock()
+
+	klog.V(4).InfoS("Retrieved and cached secret credentials", "secretName", secretName, "secretNamespace", secretNamespace)
+	return awsConfig, nil
+}
+
+// getDriverCredentials returns the driver-level AWS configuration with caching
+func (p *Provider) getDriverCredentials(ctx context.Context) (aws.Config, error) {
+	cacheKey := "driver-credentials"
+
+	// Check cache first
+	p.cacheMutex.RLock()
+	if entry, exists := p.credentialCache[cacheKey]; exists && time.Now().Before(entry.ExpiresAt) {
+		p.cacheMutex.RUnlock()
+		klog.V(5).InfoS("Using cached driver credentials")
+		return entry.Config, nil
+	}
+	p.cacheMutex.RUnlock()
+
+	// Load driver credentials using default credential chain
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return aws.Config{}, err
+	}
+
+	// Cache the driver credentials
+	p.cacheMutex.Lock()
+	p.credentialCache[cacheKey] = &CredentialCacheEntry{
+		Config:    cfg,
+		ExpiresAt: time.Now().Add(p.cacheTTL),
+	}
+	p.cacheMutex.Unlock()
+
+	klog.V(4).InfoS("Loaded and cached driver credentials")
+	return cfg, nil
+}
+
+// ClearCache clears the credential cache (useful for testing or forced refresh)
+func (p *Provider) ClearCache() {
+	p.cacheMutex.Lock()
+	defer p.cacheMutex.Unlock()
+
+	p.credentialCache = make(map[string]*CredentialCacheEntry)
+	klog.V(4).InfoS("Cleared credential cache")
+}
+
+// GetCacheStats returns cache statistics for monitoring
+func (p *Provider) GetCacheStats() (total int, expired int) {
+	p.cacheMutex.RLock()
+	defer p.cacheMutex.RUnlock()
+
+	now := time.Now()
+	total = len(p.credentialCache)
+
+	for _, entry := range p.credentialCache {
+		if now.After(entry.ExpiresAt) {
+			expired++
+		}
+	}
+
+	return total, expired
+}
+
+// SetCacheTTL updates the cache TTL (useful for testing or runtime configuration)
+func (p *Provider) SetCacheTTL(ttl time.Duration) {
+	p.cacheTTL = ttl
+	klog.V(4).InfoS("Updated credential cache TTL", "ttl", ttl)
+}
+
+// ValidateSecretCredentials performs basic validation of AWS credentials in a Kubernetes secret.
+// This validates only the presence of required fields.
+func (p *Provider) ValidateSecretCredentials(secret *corev1.Secret) error {
+	if secret == nil {
+		return fmt.Errorf("secret is nil")
+	}
+
+	if secret.Data == nil {
+		return fmt.Errorf("secret has no data")
+	}
+
+	// Check for required AWS credential fields
+	accessKeyID := secret.Data[constants.AccessKeyIDField]
+	secretAccessKey := secret.Data[constants.SecretAccessKeyField]
+
+	if len(accessKeyID) == 0 {
+		return fmt.Errorf("secret missing required field: %s", constants.AccessKeyIDField)
+	}
+
+	if len(secretAccessKey) == 0 {
+		return fmt.Errorf("secret missing required field: %s", constants.SecretAccessKeyField)
+	}
+
+	return nil
+}
+
+// CreateAWSConfigFromSecret creates an AWS configuration using credentials from a Kubernetes secret.
+// The secret must contain at least access_key_id and secret_access_key fields.
+// Optional fields include session_token and region.
+func (p *Provider) CreateAWSConfigFromSecret(secret *corev1.Secret) (aws.Config, error) {
+	// Validate the secret first
+	if err := p.ValidateSecretCredentials(secret); err != nil {
+		return aws.Config{}, err
+	}
+
+	// Extract credentials
+	accessKeyID := strings.TrimSpace(string(secret.Data[constants.AccessKeyIDField]))
+	secretAccessKey := strings.TrimSpace(string(secret.Data[constants.SecretAccessKeyField]))
+
+	// Optional session token for temporary credentials
+	var sessionToken string
+	if token := secret.Data[constants.SessionTokenField]; len(token) > 0 {
+		sessionToken = strings.TrimSpace(string(token))
+	}
+
+	// Optional region override
+	var region string
+	if regionData := secret.Data[constants.RegionField]; len(regionData) > 0 {
+		region = strings.TrimSpace(string(regionData))
+	}
+
+	// Create static credential provider
+	credsProvider := credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)
+
+	// Load base config with static credentials
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithCredentialsProvider(credsProvider),
+	)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to create AWS config: %w", err)
+	}
+
+	// Override region if provided in secret
+	if region != "" {
+		cfg.Region = region
+	}
+
+	return cfg, nil
+}

--- a/pkg/driver/controller/credentialprovider/provider_test.go
+++ b/pkg/driver/controller/credentialprovider/provider_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,13 +18,14 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
 	if provider.client != client {
 		t.Error("Expected client to be set correctly")
 	}
-	if provider.credentialCache == nil {
+	if provider.cache == nil {
 		t.Error("Expected credential cache to be initialized")
 	}
 	if provider.cacheTTL != 5*time.Minute {
@@ -34,6 +34,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewWithCacheTTL(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	customTTL := 10 * time.Minute
 	provider := NewWithCacheTTL(client, customTTL)
@@ -44,6 +45,7 @@ func TestNewWithCacheTTL(t *testing.T) {
 }
 
 func TestProvideForCreateVolume_DriverCredentials(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -63,6 +65,7 @@ func TestProvideForCreateVolume_DriverCredentials(t *testing.T) {
 }
 
 func TestProvideForCreateVolume_ProvisionerSecret(t *testing.T) {
+	t.Parallel()
 	// Create a secret with valid AWS credentials
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,6 +100,7 @@ func TestProvideForCreateVolume_ProvisionerSecret(t *testing.T) {
 }
 
 func TestProvideForCreateVolume_ProvisionerSecret_Missing(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -118,6 +122,7 @@ func TestProvideForCreateVolume_ProvisionerSecret_Missing(t *testing.T) {
 }
 
 func TestProvideForDeleteVolume_DriverCredentials(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -138,6 +143,7 @@ func TestProvideForDeleteVolume_DriverCredentials(t *testing.T) {
 }
 
 func TestProvideForDeleteVolume_ProvisionerSecret(t *testing.T) {
+	t.Parallel()
 	// Create a secret with valid AWS credentials
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -171,6 +177,7 @@ func TestProvideForDeleteVolume_ProvisionerSecret(t *testing.T) {
 }
 
 func TestProvideForDeleteVolume_ProvisionerSecret_MissingNamespace(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -191,6 +198,7 @@ func TestProvideForDeleteVolume_ProvisionerSecret_MissingNamespace(t *testing.T)
 }
 
 func TestProvideForNodePublish_NodePublishSecret(t *testing.T) {
+	t.Parallel()
 	// Create a secret with valid AWS credentials
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -225,6 +233,7 @@ func TestProvideForNodePublish_NodePublishSecret(t *testing.T) {
 }
 
 func TestGetCredentialsFor_CreateVolume(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -244,6 +253,7 @@ func TestGetCredentialsFor_CreateVolume(t *testing.T) {
 }
 
 func TestGetCredentialsFor_NodePublishVolume(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -263,6 +273,7 @@ func TestGetCredentialsFor_NodePublishVolume(t *testing.T) {
 }
 
 func TestGetCredentialsFor_UnsupportedOperation(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 	provider := New(client)
 
@@ -282,6 +293,7 @@ func TestGetCredentialsFor_UnsupportedOperation(t *testing.T) {
 }
 
 func TestCredentialCaching(t *testing.T) {
+	t.Parallel()
 	// Create a secret with valid AWS credentials
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -332,6 +344,7 @@ func TestCredentialCaching(t *testing.T) {
 }
 
 func TestCredentialCacheExpiration(t *testing.T) {
+	t.Parallel()
 	// Create a secret with valid AWS credentials
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -377,6 +390,7 @@ func TestCredentialCacheExpiration(t *testing.T) {
 }
 
 func TestValidateSecretCredentials_Valid(t *testing.T) {
+	t.Parallel()
 	secret := &corev1.Secret{
 		Data: map[string][]byte{
 			constants.AccessKeyIDField:     []byte("AKIATEST"),
@@ -394,6 +408,7 @@ func TestValidateSecretCredentials_Valid(t *testing.T) {
 }
 
 func TestValidateSecretCredentials_MissingAccessKey(t *testing.T) {
+	t.Parallel()
 	secret := &corev1.Secret{
 		Data: map[string][]byte{
 			constants.SecretAccessKeyField: []byte("test-secret-key"),
@@ -415,6 +430,7 @@ func TestValidateSecretCredentials_MissingAccessKey(t *testing.T) {
 }
 
 func TestValidateSecretCredentials_MissingSecretKey(t *testing.T) {
+	t.Parallel()
 	secret := &corev1.Secret{
 		Data: map[string][]byte{
 			constants.AccessKeyIDField: []byte("AKIATEST"),
@@ -436,6 +452,7 @@ func TestValidateSecretCredentials_MissingSecretKey(t *testing.T) {
 }
 
 func TestValidateSecretCredentials_NoData(t *testing.T) {
+	t.Parallel()
 	secret := &corev1.Secret{}
 
 	client := fake.NewSimpleClientset()
@@ -453,13 +470,31 @@ func TestValidateSecretCredentials_NoData(t *testing.T) {
 }
 
 func TestClearCache(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	t.Parallel()
+	// Create a secret and populate the cache through normal code path
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
 	provider := New(client)
 
-	// Populate cache manually for testing
-	provider.credentialCache["test-key"] = &CredentialCacheEntry{
-		Config:    aws.Config{},
-		ExpiresAt: time.Now().Add(1 * time.Minute),
+	params := &storageclass.Parameters{
+		ProvisionerSecretName:      "test-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	_, err := provider.ProvideForCreateVolume(context.TODO(), params)
+	if err != nil {
+		t.Fatalf("Expected no error populating cache, got: %v", err)
 	}
 
 	// Verify cache has entry
@@ -469,7 +504,7 @@ func TestClearCache(t *testing.T) {
 	}
 
 	// Clear cache
-	provider.ClearCache()
+	provider.clearCache()
 
 	// Verify cache is empty
 	total, _ = provider.GetCacheStats()
@@ -491,6 +526,7 @@ func TestSetCacheTTL(t *testing.T) {
 }
 
 func TestMixedCredentialScenarios(t *testing.T) {
+	t.Parallel()
 	// Create secrets for different tiers
 	provisionerSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -554,6 +590,7 @@ func TestMixedCredentialScenarios(t *testing.T) {
 }
 
 func TestAPIRateLimiting(t *testing.T) {
+	t.Parallel()
 	// Create a secret
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -631,6 +668,7 @@ func containsString(s, substr string) bool {
 
 // Mock API failures for integration testing
 func TestAPIFailureHandling(t *testing.T) {
+	t.Parallel()
 	client := fake.NewSimpleClientset()
 
 	// Add a reactor to simulate API failures

--- a/pkg/driver/controller/credentialprovider/provider_test.go
+++ b/pkg/driver/controller/credentialprovider/provider_test.go
@@ -1,0 +1,658 @@
+package credentialprovider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/storageclass"
+)
+
+func TestNew(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	if provider.client != client {
+		t.Error("Expected client to be set correctly")
+	}
+	if provider.credentialCache == nil {
+		t.Error("Expected credential cache to be initialized")
+	}
+	if provider.cacheTTL != 5*time.Minute {
+		t.Error("Expected default cache TTL to be 5 minutes")
+	}
+}
+
+func TestNewWithCacheTTL(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	customTTL := 10 * time.Minute
+	provider := NewWithCacheTTL(client, customTTL)
+
+	if provider.cacheTTL != customTTL {
+		t.Errorf("Expected cache TTL to be %v, got %v", customTTL, provider.cacheTTL)
+	}
+}
+
+func TestProvideForCreateVolume_DriverCredentials(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		AuthTier: storageclass.DriverCredentials,
+	}
+
+	config, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for driver credentials, got: %v", err)
+	}
+
+	// Verify we got a valid AWS config (should have default values from AWS SDK)
+	if config.Region == "" && config.Credentials == nil {
+		t.Error("Expected AWS config to have either region or credentials set")
+	}
+}
+
+func TestProvideForCreateVolume_ProvisionerSecret(t *testing.T) {
+	// Create a secret with valid AWS credentials
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-provisioner-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+			constants.RegionField:          []byte("us-east-1"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "test-provisioner-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	config, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for provisioner secret, got: %v", err)
+	}
+
+	// Verify the config has the correct region from secret
+	if config.Region != "us-east-1" {
+		t.Errorf("Expected region us-east-1, got %s", config.Region)
+	}
+}
+
+func TestProvideForCreateVolume_ProvisionerSecret_Missing(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "missing-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	_, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err == nil {
+		t.Fatal("Expected error for missing secret")
+	}
+
+	expectedError := "failed to retrieve secret test-namespace/missing-secret"
+	if !containsString(err.Error(), expectedError) {
+		t.Errorf("Expected error to contain %q, got: %v", expectedError, err)
+	}
+}
+
+func TestProvideForDeleteVolume_DriverCredentials(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	// Volume context without secret references (created with driver credentials)
+	volumeContext := map[string]string{
+		"bucket": "test-bucket",
+	}
+
+	config, err := provider.ProvideForDeleteVolume(context.TODO(), volumeContext)
+	if err != nil {
+		t.Fatalf("Expected no error for driver credentials, got: %v", err)
+	}
+
+	// Verify we got a valid AWS config
+	if config.Region == "" && config.Credentials == nil {
+		t.Error("Expected AWS config to have either region or credentials set")
+	}
+}
+
+func TestProvideForDeleteVolume_ProvisionerSecret(t *testing.T) {
+	// Create a secret with valid AWS credentials
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-provisioner-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
+	provider := New(client)
+
+	// Volume context with secret references (created with provisioner secret)
+	volumeContext := map[string]string{
+		constants.VolumeContextProvisionerSecretNameKey:      "test-provisioner-secret",
+		constants.VolumeContextProvisionerSecretNamespaceKey: "test-namespace",
+	}
+
+	config, err := provider.ProvideForDeleteVolume(context.TODO(), volumeContext)
+	if err != nil {
+		t.Fatalf("Expected no error for provisioner secret, got: %v", err)
+	}
+
+	// Verify we got a valid AWS config
+	if config.Credentials == nil {
+		t.Error("Expected AWS config to have credentials set")
+	}
+}
+
+func TestProvideForDeleteVolume_ProvisionerSecret_MissingNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	// Volume context with only secret name (missing namespace)
+	volumeContext := map[string]string{
+		constants.VolumeContextProvisionerSecretNameKey: "test-secret",
+	}
+
+	_, err := provider.ProvideForDeleteVolume(context.TODO(), volumeContext)
+	if err == nil {
+		t.Fatal("Expected error for missing secret namespace")
+	}
+
+	expectedError := "volume context has provisioner secret name but missing namespace"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got: %v", expectedError, err)
+	}
+}
+
+func TestProvideForNodePublish_NodePublishSecret(t *testing.T) {
+	// Create a secret with valid AWS credentials
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-node-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+			constants.SessionTokenField:    []byte("test-session-token"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		NodePublishSecretName:      "test-node-secret",
+		NodePublishSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	config, err := provider.ProvideForNodePublish(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for node publish secret, got: %v", err)
+	}
+
+	// Verify we got a valid AWS config
+	if config.Credentials == nil {
+		t.Error("Expected AWS config to have credentials set")
+	}
+}
+
+func TestGetCredentialsFor_CreateVolume(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		AuthTier: storageclass.DriverCredentials,
+	}
+
+	config, err := provider.GetCredentialsFor(context.TODO(), "CreateVolume", parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for CreateVolume operation, got: %v", err)
+	}
+
+	// Verify we got a valid AWS config
+	if config.Region == "" && config.Credentials == nil {
+		t.Error("Expected AWS config to have either region or credentials set")
+	}
+}
+
+func TestGetCredentialsFor_NodePublishVolume(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		AuthTier: storageclass.DriverCredentials,
+	}
+
+	config, err := provider.GetCredentialsFor(context.TODO(), "NodePublishVolume", parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for NodePublishVolume operation, got: %v", err)
+	}
+
+	// Verify we got a valid AWS config
+	if config.Region == "" && config.Credentials == nil {
+		t.Error("Expected AWS config to have either region or credentials set")
+	}
+}
+
+func TestGetCredentialsFor_UnsupportedOperation(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		AuthTier: storageclass.DriverCredentials,
+	}
+
+	_, err := provider.GetCredentialsFor(context.TODO(), "UnsupportedOperation", parameters)
+	if err == nil {
+		t.Fatal("Expected error for unsupported operation")
+	}
+
+	expectedError := "unsupported operation \"UnsupportedOperation\" for credential resolution"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got: %v", expectedError, err)
+	}
+}
+
+func TestCredentialCaching(t *testing.T) {
+	// Create a secret with valid AWS credentials
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
+	provider := NewWithCacheTTL(client, 1*time.Minute)
+
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "test-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	// First call should hit the API
+	_, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify cache has been populated
+	total, expired := provider.GetCacheStats()
+	if total != 1 {
+		t.Errorf("Expected 1 cached entry, got %d", total)
+	}
+	if expired != 0 {
+		t.Errorf("Expected 0 expired entries, got %d", expired)
+	}
+
+	// Second call should use cache (no additional API calls)
+	callsBefore := len(client.Actions())
+	_, err = provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	callsAfter := len(client.Actions())
+
+	if callsAfter != callsBefore {
+		t.Error("Expected second call to use cache, but API was called again")
+	}
+}
+
+func TestCredentialCacheExpiration(t *testing.T) {
+	// Create a secret with valid AWS credentials
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
+	// Very short TTL for testing expiration
+	provider := NewWithCacheTTL(client, 1*time.Millisecond)
+
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "test-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	// First call
+	_, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Wait for cache to expire
+	time.Sleep(10 * time.Millisecond)
+
+	// Second call should hit API again due to expiration
+	callsBefore := len(client.Actions())
+	_, err = provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	callsAfter := len(client.Actions())
+
+	if callsAfter <= callsBefore {
+		t.Error("Expected second call to hit API again due to cache expiration")
+	}
+}
+
+func TestValidateSecretCredentials_Valid(t *testing.T) {
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	err := provider.ValidateSecretCredentials(secret)
+	if err != nil {
+		t.Errorf("Expected no error for valid secret, got: %v", err)
+	}
+}
+
+func TestValidateSecretCredentials_MissingAccessKey(t *testing.T) {
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	err := provider.ValidateSecretCredentials(secret)
+	if err == nil {
+		t.Fatal("Expected error for missing access key")
+	}
+
+	expectedError := fmt.Sprintf("secret missing required field: %s", constants.AccessKeyIDField)
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got: %v", expectedError, err)
+	}
+}
+
+func TestValidateSecretCredentials_MissingSecretKey(t *testing.T) {
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			constants.AccessKeyIDField: []byte("AKIATEST"),
+		},
+	}
+
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	err := provider.ValidateSecretCredentials(secret)
+	if err == nil {
+		t.Fatal("Expected error for missing secret key")
+	}
+
+	expectedError := fmt.Sprintf("secret missing required field: %s", constants.SecretAccessKeyField)
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got: %v", expectedError, err)
+	}
+}
+
+func TestValidateSecretCredentials_NoData(t *testing.T) {
+	secret := &corev1.Secret{}
+
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	err := provider.ValidateSecretCredentials(secret)
+	if err == nil {
+		t.Fatal("Expected error for secret with no data")
+	}
+
+	expectedError := "secret has no data"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got: %v", expectedError, err)
+	}
+}
+
+func TestClearCache(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	// Populate cache manually for testing
+	provider.credentialCache["test-key"] = &CredentialCacheEntry{
+		Config:    aws.Config{},
+		ExpiresAt: time.Now().Add(1 * time.Minute),
+	}
+
+	// Verify cache has entry
+	total, _ := provider.GetCacheStats()
+	if total != 1 {
+		t.Errorf("Expected 1 cached entry before clear, got %d", total)
+	}
+
+	// Clear cache
+	provider.ClearCache()
+
+	// Verify cache is empty
+	total, _ = provider.GetCacheStats()
+	if total != 0 {
+		t.Errorf("Expected 0 cached entries after clear, got %d", total)
+	}
+}
+
+func TestSetCacheTTL(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := New(client)
+
+	newTTL := 10 * time.Minute
+	provider.SetCacheTTL(newTTL)
+
+	if provider.cacheTTL != newTTL {
+		t.Errorf("Expected cache TTL to be %v, got %v", newTTL, provider.cacheTTL)
+	}
+}
+
+func TestMixedCredentialScenarios(t *testing.T) {
+	// Create secrets for different tiers
+	provisionerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "provisioner-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIAPROVISIONER"),
+			constants.SecretAccessKeyField: []byte("provisioner-secret-key"),
+		},
+	}
+
+	nodeSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIANODE"),
+			constants.SecretAccessKeyField: []byte("node-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(provisionerSecret, nodeSecret)
+	provider := New(client)
+
+	// Test mixed credential scenario
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "provisioner-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		NodePublishSecretName:      "node-secret",
+		NodePublishSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	// Controller operations should use provisioner secret
+	controllerConfig, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for controller credentials, got: %v", err)
+	}
+
+	// Node operations should use node-publish secret
+	nodeConfig, err := provider.ProvideForNodePublish(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error for node credentials, got: %v", err)
+	}
+
+	// Verify different credentials are used (both should have credentials set)
+	if controllerConfig.Credentials == nil {
+		t.Error("Expected controller config to have credentials set")
+	}
+	if nodeConfig.Credentials == nil {
+		t.Error("Expected node config to have credentials set")
+	}
+
+	// Verify cache has separate entries for different secrets
+	total, _ := provider.GetCacheStats()
+	if total != 2 {
+		t.Errorf("Expected 2 cached entries (one for each secret), got %d", total)
+	}
+}
+
+func TestAPIRateLimiting(t *testing.T) {
+	// Create a secret
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			constants.AccessKeyIDField:     []byte("AKIATEST"),
+			constants.SecretAccessKeyField: []byte("test-secret-key"),
+		},
+	}
+
+	client := fake.NewSimpleClientset(secret)
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "test-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	// Test caching by making sequential calls
+	_, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error from first call, got: %v", err)
+	}
+
+	// Count initial API calls
+	firstCallCount := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" {
+			firstCallCount++
+		}
+	}
+
+	// Second call should use cache (no additional API calls)
+	_, err = provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err != nil {
+		t.Fatalf("Expected no error from second call, got: %v", err)
+	}
+
+	// Count API calls after second call
+	secondCallCount := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" {
+			secondCallCount++
+		}
+	}
+
+	// Should have made one API call for the first request, but not for the second
+	if firstCallCount != 1 {
+		t.Errorf("Expected 1 API call after first request, got %d", firstCallCount)
+	}
+
+	if secondCallCount != firstCallCount {
+		t.Errorf("Expected cached second call to not make additional API calls, but got %d calls vs %d", secondCallCount, firstCallCount)
+	}
+
+	// Verify cache statistics
+	total, expired := provider.GetCacheStats()
+	if total != 1 {
+		t.Errorf("Expected 1 cached entry, got %d", total)
+	}
+	if expired != 0 {
+		t.Errorf("Expected 0 expired entries, got %d", expired)
+	}
+}
+
+// Helper function to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > len(substr) && containsString(s[1:], substr)) ||
+		(len(s) >= len(substr) && s[:len(substr)] == substr))
+}
+
+// Mock API failures for integration testing
+func TestAPIFailureHandling(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	// Add a reactor to simulate API failures
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, kerrors.NewInternalError(fmt.Errorf("internal server error"))
+	})
+
+	provider := New(client)
+
+	parameters := &storageclass.Parameters{
+		ProvisionerSecretName:      "test-secret",
+		ProvisionerSecretNamespace: "test-namespace",
+		AuthTier:                   storageclass.SecretCredentials,
+	}
+
+	_, err := provider.ProvideForCreateVolume(context.TODO(), parameters)
+	if err == nil {
+		t.Fatal("Expected error when API fails")
+	}
+
+	expectedError := "failed to retrieve secret test-namespace/test-secret"
+	if !containsString(err.Error(), expectedError) {
+		t.Errorf("Expected error to contain %q, got: %v", expectedError, err)
+	}
+}

--- a/pkg/driver/storageclass/parameters.go
+++ b/pkg/driver/storageclass/parameters.go
@@ -6,18 +6,8 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
-)
 
-// CSI secret parameters as defined by the CSI specification
-// These are the only parameters supported for dynamic provisioning credential management
-const (
-	// CSI standard provisioner secret parameters (for controller operations)
-	ProvisionerSecretNameKey      = "csi.storage.k8s.io/provisioner-secret-name"
-	ProvisionerSecretNamespaceKey = "csi.storage.k8s.io/provisioner-secret-namespace"
-
-	// CSI standard node publish secret parameters (for node operations)
-	NodePublishSecretNameKey      = "csi.storage.k8s.io/node-publish-secret-name"
-	NodePublishSecretNamespaceKey = "csi.storage.k8s.io/node-publish-secret-namespace"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 )
 
 // Parameters represents parsed and validated StorageClass parameters for dynamic provisioning
@@ -58,10 +48,10 @@ func ParseAndValidate(parameters map[string]string) (*Parameters, error) {
 	enforceCSIDriverParameterPolicy(params)
 
 	// Parse and validate CSI secret parameters
-	provisionerSecretName := strings.TrimSpace(params[ProvisionerSecretNameKey])
-	provisionerSecretNamespace := strings.TrimSpace(params[ProvisionerSecretNamespaceKey])
-	nodePublishSecretName := strings.TrimSpace(params[NodePublishSecretNameKey])
-	nodePublishSecretNamespace := strings.TrimSpace(params[NodePublishSecretNamespaceKey])
+	provisionerSecretName := strings.TrimSpace(params[constants.ProvisionerSecretNameKey])
+	provisionerSecretNamespace := strings.TrimSpace(params[constants.ProvisionerSecretNamespaceKey])
+	nodePublishSecretName := strings.TrimSpace(params[constants.NodePublishSecretNameKey])
+	nodePublishSecretNamespace := strings.TrimSpace(params[constants.NodePublishSecretNamespaceKey])
 
 	// Validate secret parameter consistency
 	if err := validateSecretParameterConsistency(provisionerSecretName, provisionerSecretNamespace, "provisioner"); err != nil {
@@ -89,10 +79,10 @@ func ParseAndValidate(parameters map[string]string) (*Parameters, error) {
 // We only support CSI standard provisioner secret parameters, all others are silently ignored
 func enforceCSIDriverParameterPolicy(parameters map[string]string) {
 	supportedParams := map[string]bool{
-		ProvisionerSecretNameKey:      true,
-		ProvisionerSecretNamespaceKey: true,
-		NodePublishSecretNameKey:      true,
-		NodePublishSecretNamespaceKey: true,
+		constants.ProvisionerSecretNameKey:      true,
+		constants.ProvisionerSecretNamespaceKey: true,
+		constants.NodePublishSecretNameKey:      true,
+		constants.NodePublishSecretNamespaceKey: true,
 	}
 
 	// Remove any parameters that are not in our supported list

--- a/pkg/driver/storageclass/parameters_test.go
+++ b/pkg/driver/storageclass/parameters_test.go
@@ -2,6 +2,8 @@ package storageclass
 
 import (
 	"testing"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 )
 
 func TestParseAndValidate(t *testing.T) {
@@ -30,8 +32,8 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "static secret parameters - secret credentials",
 			parameters: map[string]string{
-				ProvisionerSecretNameKey:      "tenant-a-creds",
-				ProvisionerSecretNamespaceKey: "tenant-a",
+				constants.ProvisionerSecretNameKey:      "tenant-a-creds",
+				constants.ProvisionerSecretNamespaceKey: "tenant-a",
 			},
 			expected: &Parameters{
 				ProvisionerSecretName:      "tenant-a-creds",
@@ -43,8 +45,8 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "secret parameters - secret credentials",
 			parameters: map[string]string{
-				ProvisionerSecretNameKey:      "web-app-storage-creds",
-				ProvisionerSecretNamespaceKey: "production",
+				constants.ProvisionerSecretNameKey:      "web-app-storage-creds",
+				constants.ProvisionerSecretNamespaceKey: "production",
 			},
 			expected: &Parameters{
 				ProvisionerSecretName:      "web-app-storage-creds",
@@ -56,8 +58,8 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "mixed secret parameters - secret credentials",
 			parameters: map[string]string{
-				ProvisionerSecretNameKey:      "app-specific-creds",
-				ProvisionerSecretNamespaceKey: "default",
+				constants.ProvisionerSecretNameKey:      "app-specific-creds",
+				constants.ProvisionerSecretNamespaceKey: "default",
 			},
 			expected: &Parameters{
 				ProvisionerSecretName:      "app-specific-creds",
@@ -69,7 +71,7 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "secret name without namespace - should error",
 			parameters: map[string]string{
-				ProvisionerSecretNameKey: "tenant-a-creds",
+				constants.ProvisionerSecretNameKey: "tenant-a-creds",
 			},
 			expected:  nil,
 			shouldErr: true,
@@ -77,7 +79,7 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "secret namespace without name - should error",
 			parameters: map[string]string{
-				ProvisionerSecretNamespaceKey: "tenant-a",
+				constants.ProvisionerSecretNamespaceKey: "tenant-a",
 			},
 			expected:  nil,
 			shouldErr: true,
@@ -85,12 +87,12 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "unsupported parameters are stripped",
 			parameters: map[string]string{
-				ProvisionerSecretNameKey:      "test-creds",
-				ProvisionerSecretNamespaceKey: "default",
-				NodePublishSecretNameKey:      "test-creds",
-				NodePublishSecretNamespaceKey: "default",
-				"customParam":                 "ignored-value",
-				"anotherParam":                "also-ignored",
+				constants.ProvisionerSecretNameKey:      "test-creds",
+				constants.ProvisionerSecretNamespaceKey: "default",
+				constants.NodePublishSecretNameKey:      "test-creds",
+				constants.NodePublishSecretNamespaceKey: "default",
+				"customParam":                           "ignored-value",
+				"anotherParam":                          "also-ignored",
 			},
 			expected: &Parameters{
 				ProvisionerSecretName:      "test-creds",
@@ -104,8 +106,8 @@ func TestParseAndValidate(t *testing.T) {
 		{
 			name: "whitespace trimming",
 			parameters: map[string]string{
-				ProvisionerSecretNameKey:      "  test-creds  ",
-				ProvisionerSecretNamespaceKey: "  default  ",
+				constants.ProvisionerSecretNameKey:      "  test-creds  ",
+				constants.ProvisionerSecretNamespaceKey: "  default  ",
 			},
 			expected: &Parameters{
 				ProvisionerSecretName:      "test-creds",


### PR DESCRIPTION
- Implement controller credential provider with granular credential resolution
- Support driver credentials and provisioner/node-publish secrets
- Add credential caching with configurable TTL for API rate limiting
- Define shared constants for CSI secret parameters

Issue: S3CSI-140