### PR TITLE
Documentation/s3 csi 152 update helm chart values and admin user guide

### DIFF
--- a/docs/admin-user-guide.md
+++ b/docs/admin-user-guide.md
@@ -2,23 +2,56 @@
 
 This guide defines roles and responsibilities for administrators managing the Scality CSI Driver for S3 and users consuming S3 storage in Kubernetes.
 
+The driver supports both **Dynamic Provisioning** (automatic S3 bucket creation and deletion if empty) and **Static Provisioning** (manual bucket and PV creation).
+
 ## Administrator Responsibilities
+
+### Common Tasks (Both Provisioning Types)
 
 - Install and configure the driver (Helm, global settings, upgrades)
 - Manage network connectivity to S3
-- Create PersistentVolumes for S3 buckets
 - Set mount options and manage credentials
 - Rotate credentials, implement least-privilege, monitor logs
 
+### Dynamic Provisioning
+
+- Create and manage StorageClasses with S3 parameters
+- Configure credential secrets for bucket operations
+- Set up credential templating for multi-tenancy
+- Monitor automatic bucket creation and deletion
+
+### Static Provisioning
+
+- Manually create S3 buckets
+- Create PersistentVolumes for existing buckets
+- Manage per-volume credential secrets
+
 ## User Responsibilities
 
-- Create PVCs referencing provided PVs
+### Dynamic Provisioning
+
+- Create PVCs referencing StorageClasses
+- Mount volumes in pods (including inline pod creation with PVCs)
+- Understand S3 consistency and error handling
+- Follow naming conventions and data management best practices
+
+### Static Provisioning
+
+- Create PVCs referencing administrator-provided PVs
 - Mount volumes in pods
 - Understand S3 consistency and error handling
 - Follow naming conventions and data management best practices
 
 ## Communication Workflows
 
-1. User requests storage (bucket, access, requirements)
-2. Admin reviews, creates bucket/PV, provides PV name
-3. User creates PVC and deploys application
+### Dynamic Provisioning Workflow
+
+1. **Administrator Setup**: Creates StorageClass with bucket parameters and credential configuration
+2. **User Storage Request**: Creates PVC referencing StorageClass (bucket created automatically)
+3. **User Application Deployment**: Deploys pods with PVC references (volume mounted automatically)
+
+### Static Provisioning Workflow
+
+1. **User Storage Request**: Requests storage (bucket, access, requirements)
+2. **Administrator Provision**: Reviews, creates bucket/PV, provides PV name
+3. **User Application Deployment**: Creates PVC and deploys application

--- a/docs/concepts-and-reference/compatibility-matrix.md
+++ b/docs/concepts-and-reference/compatibility-matrix.md
@@ -9,10 +9,10 @@ This page documents version compatibility between the Scality CSI Driver for S3,
 
 | S3 Implementation | Tested Versions |Notes                            |
 |-------------------|-----------------|---------------------------------|
-| Scality RING      | 9.4.2 or newer  | Full support with driver v1.0.0 |
+| Scality RING      | 9.4.2 or newer  | Full support with driver v1.x |
 
 ## Kubernetes Compatibility
 
 | Kubernetes Version |Notes                            |
 |--------------------|---------------------------------|
-| 1.30 and above     | Full support with driver v1.0.0 |
+| 1.30 and above     | Full support with driver v1.x |

--- a/docs/concepts-and-reference/helm-chart-configuration-reference.md
+++ b/docs/concepts-and-reference/helm-chart-configuration-reference.md
@@ -18,7 +18,7 @@ These parameters configure the overall behavior of the CSI driver components.
 |------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|-----------------------------|
 | `image.repository`                                   | The container image repository for the CSI driver.                                                                                                 | `ghcr.io/scality/mountpoint-s3-csi-driver`             | No                          |
 | `image.pullPolicy`                                   | The image pull policy.                                                                                                                             | `IfNotPresent`                                         | No                          |
-| `image.tag`                                          | The image tag for the CSI driver. Overrides the chart's `appVersion` if set.                                                                       | `1.2.1`                                                | No                          |
+| `image.tag`                                          | The image tag for the CSI driver. Overrides the chart's `appVersion` if set.                                                                       | `1.2.0`                                                | No                          |
 
 ## S3 Global Configuration
 


### PR DESCRIPTION
- Update matrix for compatibility with 1.x driver version instead of 1.0.0 only as we didn't break anything in 1.0.0 and above
- Update Helm chart configuration docs to include s3 endpoint URL and S3 region new values with backward compatibility
- Update the admin and user guides for dynamic provisioning