### PR TITLE
S3CSI-137: Move provisioner image to values.yaml

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -87,7 +87,8 @@ spec:
                   name: {{ .Values.s3CredentialSecret.name }}
                   key: {{ .Values.s3CredentialSecret.secretAccessKey }}
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: {{ .Values.sidecars.csiProvisioner.image.repository }}:{{ .Values.sidecars.csiProvisioner.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.csiProvisioner.image.pullPolicy }}
           args:
             - "--csi-address=/csi/csi.sock"
             - "--v=2"

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -99,6 +99,12 @@ sidecars:
       - mountPath: /csi
         name: plugin-dir
     resources: {}
+  csiProvisioner:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-provisioner
+      tag: v5.1.0
+      pullPolicy: IfNotPresent
+    resources: {}
 
 # Init container configuration
 initContainer:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -101,7 +101,7 @@ sidecars:
     resources: {}
   csiProvisioner:
     image:
-      repository: registry.k8s.io/sig-storage/csi-provisioner
+      repository: ghcr.io/scality/mountpoint-s3-csi-driver/csi-provisioner
       tag: v5.3.0
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -102,7 +102,7 @@ sidecars:
   csiProvisioner:
     image:
       repository: registry.k8s.io/sig-storage/csi-provisioner
-      tag: v5.1.0
+      tag: v5.3.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -75,6 +75,7 @@ node:
 # Sidecar containers configuration
 sidecars:
   nodeDriverRegistrar:
+    # Source: https://github.com/kubernetes-csi/node-driver-registrar/releases
     image:
       repository: ghcr.io/scality/mountpoint-s3-csi-driver/csi-node-driver-registrar
       tag: v2.14.0
@@ -91,6 +92,7 @@ sidecars:
         mountPath: /registration
     resources: {}
   livenessProbe:
+    # Source: https://github.com/kubernetes-csi/livenessprobe/releases
     image:
       repository: ghcr.io/scality/mountpoint-s3-csi-driver/livenessprobe
       tag: v2.16.0
@@ -100,6 +102,7 @@ sidecars:
         name: plugin-dir
     resources: {}
   csiProvisioner:
+    # Source: https://github.com/kubernetes-csi/external-provisioner/releases
     image:
       repository: ghcr.io/scality/mountpoint-s3-csi-driver/csi-provisioner
       tag: v5.3.0


### PR DESCRIPTION
Updates image to use scality GHCR
and this is also needed for end users to configure the image as they might use their own registry