### PR TITLE
S3CSI-104: prepare release 1.2.0 with version bumps and release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=1.1.1
+VERSION=1.2.0
 
 # List of allowed licenses in the CSI Driver's dependencies.
 # See https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28 for list of canonical names for licenses.

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: scality-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Scality CSI Driver for S3. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
-version: 1.1.1
+version: 1.2.0
 kubeVersion: ">=1.30.0-0"
 home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -16,7 +16,7 @@ s3:
   # This is a sample value, replace with the actual RING S3 endpoint URL
   endpointUrl: "http://s3.example.com:8000"
   # Default AWS region to use for all volume mounts
-  # The Region can be overridden at per volume at persistent volume level by setting spec.mountOptions.region
+  # The Region can be overridden at persistent volume level by setting
   region: "us-east-1"
 
 # Container image configuration
@@ -24,7 +24,7 @@ image:
   repository: ghcr.io/scality/mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.1.1"
+  tag: "1.2.0"
 
 # Node plugin configuration (DaemonSet)
 node:

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,13 +34,14 @@ Container images for the Scality CSI Driver for S3 are hosted on GHCR:
 
 | Driver Version | Image URL                                                                 |
 |---------------|----------------------------------------------------------------------------|
-| 1.1.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.1`                           |
+| 1.2.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.2.0`                           |
 
 Review [release notes](release-notes.md) for breaking changes and the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for complete changelog details.
 
 ??? note "Previous Images"
     | Driver Version | Image URL                                                                 |
     |---------------|----------------------------------------------------------------------------|
+    | 1.1.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.1`                           |
     | 1.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.1.0`                           |
     | 1.0.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.1`                           |
     | 1.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0`                           |

--- a/docs/driver-deployment/prerequisites.md
+++ b/docs/driver-deployment/prerequisites.md
@@ -25,9 +25,10 @@ The deployment of the Scality CSI Driver for S3 requires access to several conta
 
 | Component | Image | Registry | Purpose |
 |-----------|-------|----------|---------|
-| **Scality CSI Driver for S3** | `ghcr.io/scality/mountpoint-s3-csi-driver:1.0.0` | GitHub Container Registry (GHCR) | Main CSI driver functionality |
+| **Scality CSI Driver for S3** | `ghcr.io/scality/mountpoint-s3-csi-driver:1.2.0` | GitHub Container Registry (GHCR) | Main CSI driver functionality |
 | **CSI Node Driver Registrar** | `ghcr.io/scality/mountpoint-s3-csi-driver/csi-node-driver-registrar:v2.14.0` | GitHub Container Registry (GHCR) | Registers CSI driver with kubelet |
 | **Liveness Probe** | `ghcr.io/scality/mountpoint-s3-csi-driver/livenessprobe:v2.15.0` | GitHub Container Registry (GHCR) | Health monitoring for CSI driver pods |
+| **CSI Provisioner** | `ghcr.io/scality/mountpoint-s3-csi-driver/csi-provisioner:v5.3.0` | GitHub Container Registry (GHCR) | External provisioner for CSI driver (Dynamic provisioning feature) |
 
 !!! note "Private Registry Configuration"
     If using a private container registry or image mirroring, update the `image.repository` values in the Helm chart configuration accordingly.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## [1.2.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.2.0)
+
+August 21, 2025
+
+### What's New
+
+- **Dynamic Provisioning**: Added support for automatic S3 bucket creation during PersistentVolumeClaim provisioning referencing a storage class.
+- **Controller Service**: Controller service is now deployed by default (previously experimental) to support dynamic provisioning.
+- **Helm Chart Updates**:
+  - Added global `s3.region` and `s3.endpointUrl` values that apply to both node and controller services.
+  - Legacy `node.s3EndpointUrl` and `node.s3Region` values are still supported and take precedence for backward compatibility.
+  - Added new `controller` section in Helm chart `values.yaml` with improved credential provider and RBAC permissions.
+  - Added configurable `images.provisioner` section in `values.yaml` for controller sidecar image configuration.
+
 ## [1.1.1](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/1.1.1)
 
 August 5, 2025


### PR DESCRIPTION
Update versions to 1.2.0
Add a requirement for a new provisioner image
add release notes