### PR TITLE
refactor: centralize CSI driver name into constants

### DIFF
--- a/cmd/scality-csi-controller/csicontroller/reconciler.go
+++ b/cmd/scality-csi-controller/csicontroller/reconciler.go
@@ -13,12 +13,13 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
 )
 
 const debugLevel = 4
 
-const mountpointCSIDriverName = "s3.csi.scality.com"
+const mountpointCSIDriverName = constants.DriverName
 
 // A Reconciler reconciles Mountpoint Pods by watching other workload Pods that's using S3 CSI Driver.
 type Reconciler struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -3,6 +3,9 @@
 package constants
 
 const (
+	// CSI driver name constant
+	DriverName = "s3.csi.scality.com"
+
 	// Secret field names for AWS credentials as expected in Kubernetes secrets
 	// These match the format used by the existing node credential provider
 	AccessKeyIDField     = "access_key_id"

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 	controllerCredProvider "github.com/scality/mountpoint-s3-csi-driver/pkg/driver/controller/credentialprovider"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
@@ -42,7 +43,7 @@ import (
 )
 
 const (
-	driverName = "s3.csi.scality.com"
+	driverName = constants.DriverName
 
 	grpcServerMaxReceiveMessageSize = 1024 * 1024 * 2 // 2MB
 

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint"
@@ -191,7 +192,7 @@ func (m *SystemdMounter) credentialWriteAndEnvPath() (writePath string, envPath 
 func hostPluginDirWithDefault() string {
 	hostPluginDir := os.Getenv("HOST_PLUGIN_DIR")
 	if hostPluginDir == "" {
-		hostPluginDir = "/var/lib/kubelet/plugins/s3.csi.scality.com/"
+		hostPluginDir = "/var/lib/kubelet/plugins/" + constants.DriverName + "/"
 	}
 	return hostPluginDir
 }

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/cluster"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,10 +15,10 @@ import (
 
 // Labels populated on spawned Mountpoint Pods.
 const (
-	LabelMountpointVersion = "s3.csi.scality.com/mountpoint-version"
-	LabelPodUID            = "s3.csi.scality.com/pod-uid"
-	LabelVolumeName        = "s3.csi.scality.com/volume-name"
-	LabelCSIDriverVersion  = "s3.csi.scality.com/mounted-by-csi-driver-version"
+	LabelMountpointVersion = constants.DriverName + "/mountpoint-version"
+	LabelPodUID            = constants.DriverName + "/pod-uid"
+	LabelVolumeName        = constants.DriverName + "/volume-name"
+	LabelCSIDriverVersion  = constants.DriverName + "/mounted-by-csi-driver-version"
 )
 
 const EmptyDirSizeLimit = 10 * 1024 * 1024 // 10MiB

--- a/tests/controller/suite_test.go
+++ b/tests/controller/suite_test.go
@@ -20,12 +20,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/scality/mountpoint-s3-csi-driver/cmd/scality-csi-controller/csicontroller"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/version"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
 )
 
 const (
-	s3CSIDriver  = "s3.csi.scality.com"
+	s3CSIDriver  = constants.DriverName
 	ebsCSIDriver = "ebs.csi.aws.com"
 )
 

--- a/tests/e2e/constants/constants.go
+++ b/tests/e2e/constants/constants.go
@@ -1,0 +1,8 @@
+// Package constants provides common constants for the E2E tests.
+// This includes the CSI driver name and other shared constants.
+package constants
+
+const (
+	// CSI driver name constant - must match the one in pkg/constants/constants.go
+	DriverName = "s3.csi.scality.com"
+)

--- a/tests/e2e/customsuites/advanced_patterns.go
+++ b/tests/e2e/customsuites/advanced_patterns.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
 )
 
 // s3AdvancedPatternsTestSuite implements TestSuite for advanced provisioning patterns
@@ -87,7 +89,7 @@ func (t *s3AdvancedPatternsTestSuite) DefineTests(driver storageframework.TestDr
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name":      provSecretName,
 				"csi.storage.k8s.io/provisioner-secret-namespace": f.Namespace.Name,
@@ -234,7 +236,7 @@ func (t *s3AdvancedPatternsTestSuite) DefineTests(driver storageframework.TestDr
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name":      provSecretName,
 				"csi.storage.k8s.io/provisioner-secret-namespace": f.Namespace.Name,
@@ -340,7 +342,7 @@ func (t *s3AdvancedPatternsTestSuite) DefineTests(driver storageframework.TestDr
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name": provSecretName,
 				// Missing secret namespace - should cause error
@@ -411,7 +413,7 @@ func testCredentialFallback(ctx context.Context, f *framework.Framework, scenari
 		ObjectMeta: metav1.ObjectMeta{
 			Name: scName,
 		},
-		Provisioner:   "s3.csi.scality.com",
+		Provisioner:   constants.DriverName,
 		Parameters:    scParams,
 		ReclaimPolicy: ptr.To(v1.PersistentVolumeReclaimDelete),
 	}

--- a/tests/e2e/customsuites/dynamic_perf.go
+++ b/tests/e2e/customsuites/dynamic_perf.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
 )
 
 // s3DynamicProvisioningPerfTestSuite implements TestSuite for performance and stress testing
@@ -91,7 +93,7 @@ func (t *s3DynamicProvisioningPerfTestSuite) DefineTests(driver storageframework
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name":      provSecretName,
 				"csi.storage.k8s.io/provisioner-secret-namespace": f.Namespace.Name,
@@ -202,7 +204,7 @@ func (t *s3DynamicProvisioningPerfTestSuite) DefineTests(driver storageframework
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":      secretName,
 					"csi.storage.k8s.io/provisioner-secret-namespace": f.Namespace.Name,
@@ -308,7 +310,7 @@ func (t *s3DynamicProvisioningPerfTestSuite) DefineTests(driver storageframework
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner:   "s3.csi.scality.com",
+				Provisioner:   constants.DriverName,
 				Parameters:    scConfig.params,
 				ReclaimPolicy: ptr.To(v1.PersistentVolumeReclaimDelete),
 			}

--- a/tests/e2e/customsuites/dynamic_provisioning_authentication.go
+++ b/tests/e2e/customsuites/dynamic_provisioning_authentication.go
@@ -17,6 +17,7 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/utils/ptr"
 
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 )
 
@@ -96,7 +97,7 @@ func (t *s3DynamicProvisioningAuthTestSuite) DefineTests(driver storageframework
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name":       provSecretName,
 				"csi.storage.k8s.io/provisioner-secret-namespace":  f.Namespace.Name,
@@ -262,7 +263,7 @@ func (t *s3DynamicProvisioningAuthTestSuite) DefineTests(driver storageframework
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name":       provSecretName,
 				"csi.storage.k8s.io/provisioner-secret-namespace":  secretNamespace.Name, // Different namespace
@@ -326,7 +327,7 @@ func (t *s3DynamicProvisioningAuthTestSuite) DefineTests(driver storageframework
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 			},
-			Provisioner: "s3.csi.scality.com",
+			Provisioner: constants.DriverName,
 			Parameters: map[string]string{
 				"csi.storage.k8s.io/provisioner-secret-name":       lisaProvSecretName,
 				"csi.storage.k8s.io/provisioner-secret-namespace":  f.Namespace.Name,

--- a/tests/e2e/customsuites/dynamic_provisioning_mount_options.go
+++ b/tests/e2e/customsuites/dynamic_provisioning_mount_options.go
@@ -22,6 +22,7 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 )
 
@@ -143,7 +144,7 @@ func (t *s3CSIDynamicProvisioningMountOptionsTestSuite) DefineTests(driver stora
 	createStorageClassWithMountOptions := func(ctx context.Context, mountOptions []string, parameters map[string]string, suffix string) *storagev1.StorageClass {
 		scName := fmt.Sprintf("mount-options-test-%s", suffix)
 
-		driverName := "s3.csi.scality.com"
+		driverName := constants.DriverName
 
 		if parameters == nil {
 			parameters = map[string]string{}

--- a/tests/e2e/customsuites/dynamic_provisioning_templating.go
+++ b/tests/e2e/customsuites/dynamic_provisioning_templating.go
@@ -43,6 +43,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
 )
 
 // s3DynamicProvisioningTemplatingTestSuite implements TestSuite for testing CSI secret templating
@@ -156,7 +158,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":      "${pvc.name}-provisioner",
 					"csi.storage.k8s.io/provisioner-secret-namespace": "${pvc.namespace}",
@@ -208,7 +210,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":      "${pvc.namespace}-secret",
 					"csi.storage.k8s.io/provisioner-secret-namespace": "${pvc.namespace}",
@@ -253,7 +255,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":      "${pv.name}-secret",
 					"csi.storage.k8s.io/provisioner-secret-namespace": "${pvc.namespace}",
@@ -348,7 +350,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":      "test-secret",
 					"csi.storage.k8s.io/provisioner-secret-namespace": nsName, // Using static namespace for this test
@@ -399,7 +401,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":      "prov-secret-ns",
 					"csi.storage.k8s.io/provisioner-secret-namespace": "${pvc.namespace}",
@@ -454,7 +456,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "default-prov",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -517,7 +519,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "default-prov2",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -574,7 +576,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "default-prov3",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -630,7 +632,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "default-prov4",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -721,7 +723,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "default-prov5",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -776,7 +778,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "default-prov6",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -842,7 +844,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "${pvc.namespace}-admin",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -902,7 +904,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "platform-admin",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}", // Same namespace for simplicity
@@ -962,7 +964,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "${pvc.annotations['team.io/name']}-admin",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",
@@ -1039,7 +1041,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "${pvc.name}-provisioner",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  secretsNs, // Static namespace for provisioner
@@ -1094,7 +1096,7 @@ func (t *s3DynamicProvisioningTemplatingTestSuite) DefineTests(driver storagefra
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
 				},
-				Provisioner: "s3.csi.scality.com",
+				Provisioner: constants.DriverName,
 				Parameters: map[string]string{
 					"csi.storage.k8s.io/provisioner-secret-name":       "${pv.name}-admin",
 					"csi.storage.k8s.io/provisioner-secret-namespace":  "${pvc.namespace}",

--- a/tests/e2e/scripts/modules/common.sh
+++ b/tests/e2e/scripts/modules/common.sh
@@ -4,6 +4,11 @@
 # Basic error handling - exit on error, undefined variables, pipe failures
 set -euo pipefail
 
+# Constants - only declare if not already set
+if [[ -z "${CSI_DRIVER_NAME:-}" ]]; then
+    readonly CSI_DRIVER_NAME="s3.csi.scality.com"
+fi
+
 # Print with timestamp
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"

--- a/tests/e2e/scripts/modules/install.sh
+++ b/tests/e2e/scripts/modules/install.sh
@@ -220,7 +220,7 @@ verify_installation() {
   # Check if CSI driver is registered first (which should happen immediately after Helm install)
   log "Checking if CSI driver is registered..."
 
-  if ! exec_cmd kubectl get csidrivers | grep -q "s3.csi.scality.com"; then
+  if ! exec_cmd kubectl get csidrivers | grep -q "$CSI_DRIVER_NAME"; then
     error "CSI driver is not registered properly. Installation may have failed."
     exec_cmd kubectl get csidrivers
     return

--- a/tests/e2e/scripts/modules/test.sh
+++ b/tests/e2e/scripts/modules/test.sh
@@ -177,7 +177,7 @@ run_verification_tests() {
   log "Verifying Scality CSI driver installation in namespace: $namespace..."
 
   # Check if the CSI driver is registered
-  if exec_cmd kubectl get csidrivers | grep -q "s3.csi.scality.com"; then
+  if exec_cmd kubectl get csidrivers | grep -q "$CSI_DRIVER_NAME"; then
     log "CSI driver is registered properly."
   else
     error "CSI driver is not registered properly."

--- a/tests/e2e/scripts/modules/uninstall.sh
+++ b/tests/e2e/scripts/modules/uninstall.sh
@@ -130,14 +130,14 @@ uninstall_csi_driver() {
   fi
 
   # Check if CSI driver is still registered
-  if exec_cmd kubectl get csidrivers | grep -q "s3.csi.scality.com"; then
-    warn "CSI driver s3.csi.scality.com is still registered. You may need to delete it manually:"
-    warn "kubectl delete csidriver s3.csi.scality.com"
+  if exec_cmd kubectl get csidrivers | grep -q "$CSI_DRIVER_NAME"; then
+    warn "CSI driver $CSI_DRIVER_NAME is still registered. You may need to delete it manually:"
+    warn "kubectl delete csidriver $CSI_DRIVER_NAME"
 
     # In force mode, automatically delete the CSI driver
     if [ "$FORCE" = true ]; then
-      log "Force mode enabled. Deleting CSI driver s3.csi.scality.com..."
-      if ! exec_cmd kubectl delete csidriver s3.csi.scality.com; then
+      log "Force mode enabled. Deleting CSI driver $CSI_DRIVER_NAME..."
+      if ! exec_cmd kubectl delete csidriver "$CSI_DRIVER_NAME"; then
         error "failed to delete CSI driver. Error code: $ERROR_CSI_DELETE"
         warn "You may need to manually delete the CSI driver registration."
         return $ERROR_CSI_DELETE

--- a/tests/e2e/testdriver.go
+++ b/tests/e2e/testdriver.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/onsi/ginkgo/v2"
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/customsuites"
 	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/pkg/s3client"
 	v1 "k8s.io/api/core/v1"
@@ -49,7 +50,7 @@ func initS3Driver() *s3Driver {
 	return &s3Driver{
 		client: s3client.New("", "", ""),
 		driverInfo: framework.DriverInfo{
-			Name:        "s3.csi.scality.com",
+			Name:        constants.DriverName,
 			MaxFileSize: framework.FileSizeLarge,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -111,7 +112,7 @@ func (d *s3Driver) GetDynamicProvisionStorageClass(
 		ObjectMeta: metav1.ObjectMeta{
 			Name: scName,
 		},
-		Provisioner: d.driverInfo.Name, // "s3.csi.scality.com"
+		Provisioner: d.driverInfo.Name, // constants.DriverName
 		Parameters: map[string]string{
 			"csi.storage.k8s.io/provisioner-secret-name":       provSecretName,
 			"csi.storage.k8s.io/provisioner-secret-namespace":  config.Framework.Namespace.Name,


### PR DESCRIPTION
Replace hardcoded "s3.csi.scality.com" references throughout codebase with centralized constants to improve maintainability.

This eliminates 25+ hardcoded driver name references and centralizes them into constants, making future driver name changes easier to manage. Documentation and Helm templates retain hardcoded values as expected.

Issue: S3CSI-21