### PR TITLE
S3CSI-170: add non-root execution and fsGroup support for SELinux compatibility

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -52,6 +52,11 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            {{- with .Values.controller.securityContext }}
+            runAsNonRoot: {{ .runAsNonRoot }}
+            runAsUser: {{ .runAsUser }}
+            runAsGroup: {{ .runAsGroup }}
+            {{- end }}
             {{- with .Values.controller.seLinuxOptions }}
             seLinuxOptions:
               user: {{ .user }}

--- a/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
@@ -23,6 +23,11 @@ spec:
         {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
       priorityClassName: system-node-critical
+      {{- with .Values.node.securityContext }}
+      securityContext:
+        fsGroup: {{ .fsGroup }}
+        fsGroupChangePolicy: {{ .fsGroupChangePolicy }}
+      {{- end }}
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -54,6 +59,11 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            {{- with .Values.node.securityContext }}
+            runAsNonRoot: {{ .runAsNonRoot }}
+            runAsUser: {{ .runAsUser }}
+            runAsGroup: {{ .runAsGroup }}
+            {{- end }}
             {{- with .Values.node.seLinuxOptions }}
             seLinuxOptions:
               user: {{ .user }}
@@ -84,6 +94,11 @@ spec:
             {{- else -}}
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            {{- with .Values.node.securityContext }}
+            runAsNonRoot: {{ .runAsNonRoot }}
+            runAsUser: {{ .runAsUser }}
+            runAsGroup: {{ .runAsGroup }}
+            {{- end }}
             {{- end }}
             {{- with .Values.node.seLinuxOptions }}
             seLinuxOptions:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -41,6 +41,12 @@ node:
   mountpointInstallPath: /opt/mountpoint-s3-csi/bin/ # should end with "/"
 
   # Security context for the CSI driver containers
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
+    fsGroupChangePolicy: "OnRootMismatch"
   seLinuxOptions:
     user: system_u
     type: super_t
@@ -129,6 +135,16 @@ controller:
     # Specifies whether a service account should be created
     create: true
     name: s3-csi-driver-controller-sa
+  # Security context for the controller containers
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+  seLinuxOptions:
+    user: system_u
+    type: super_t
+    role: system_r
+    level: s0
 
 # Experimental features. To be used only in development environments.
 experimental:

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -39,7 +39,9 @@ import (
 var kubeletPath = util.KubeletPath()
 
 var (
-	systemdNodeCaps    = []csi.NodeServiceCapability_RPC_Type{}
+	systemdNodeCaps    = []csi.NodeServiceCapability_RPC_Type{
+		csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
+	}
 	podMounterNodeCaps = []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
 	}
@@ -125,7 +127,7 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 
 	args := mountpoint.ParseArgs(mountpointArgs)
 
-	if capMount := volCap.GetMount(); capMount != nil && util.UsePodMounter() {
+	if capMount := volCap.GetMount(); capMount != nil {
 		if volumeMountGroup := capMount.GetVolumeMountGroup(); volumeMountGroup != "" {
 			// We need to add the following flags to support fsGroup
 			// If these flags were already set by customer in PV mountOptions then we won't override them

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -39,7 +39,7 @@ import (
 var kubeletPath = util.KubeletPath()
 
 var (
-	systemdNodeCaps    = []csi.NodeServiceCapability_RPC_Type{
+	systemdNodeCaps = []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
 	}
 	podMounterNodeCaps = []csi.NodeServiceCapability_RPC_Type{


### PR DESCRIPTION
Security for S3 Linux compatibility

- Add non-root security context with runAsUser/runAsGroup 65534 (nobody)
- Enable VOLUME_MOUNT_GROUP capability for both systemd and Pod Mounter
- Configure fsGroup and fsGroupChangePolicy for proper volume permissions
- Update Helm templates to apply security contexts at Pod and container levels
- Support fsGroup handling in NodePublishVolume for all mounting strategies