### PR TITLE
feat: Add controller reconciler with RBAC + headroom

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -41,6 +41,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+        # CSI Controller Service for dynamic provisioning
         - name: s3-csi-controller
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -59,7 +60,6 @@ spec:
               role: {{ .role }}
               level: {{ .level }}
             {{- end }}
-          # TODO: Healthcheck for the controller.
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -86,6 +86,37 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.s3CredentialSecret.name }}
                   key: {{ .Values.s3CredentialSecret.secretAccessKey }}
+        # Reconciler for MountpointS3PodAttachment CRDs
+        - name: s3-pod-reconciler
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/bin/scality-csi-controller"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            # Environment variables for Mountpoint Pod configuration
+            - name: MOUNTPOINT_NAMESPACE
+              value: {{ .Values.mountpointPod.namespace | quote }}
+            - name: MOUNTPOINT_VERSION
+              value: {{ .Values.node.mountpointVersion | quote }}
+            - name: MOUNTPOINT_PRIORITY_CLASS_NAME
+              value: {{ .Values.mountpointPod.priorityClassName | quote }}
+            - name: MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME
+              value: {{ .Values.mountpointPod.preemptingPriorityClassName | quote }}
+            - name: MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME
+              value: {{ .Values.mountpointPod.headroomPriorityClassName | quote }}
+            - name: MOUNTPOINT_IMAGE
+              value: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+            - name: MOUNTPOINT_HEADROOM_IMAGE
+              value: {{ .Values.mountpointPod.headroomImage | quote }}
+            - name: MOUNTPOINT_IMAGE_PULL_POLICY
+              value: {{ .Values.image.pullPolicy | quote }}
         - name: csi-provisioner
           image: {{ .Values.sidecars.csiProvisioner.image.repository }}:{{ .Values.sidecars.csiProvisioner.image.tag }}
           imagePullPolicy: {{ .Values.sidecars.csiProvisioner.image.pullPolicy }}

--- a/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -40,6 +40,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+  # Permission to manage MountpointS3PodAttachment CRDs
+  - apiGroups: ["s3.csi.scality.com"]
+    resources: ["mountpoints3podattachments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Permission to create and manage Mountpoint Pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/scality-csi-controller/csicontroller/reconciler.go
+++ b/cmd/scality-csi-controller/csicontroller/reconciler.go
@@ -4,22 +4,35 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/go-logr/logr" // For logr.Logger type used by controller-runtime
+	crdv2 "github.com/scality/mountpoint-s3-csi-driver/pkg/api/v2"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
 )
 
 const debugLevel = 4
 
-const mountpointCSIDriverName = constants.DriverName
+const (
+	mountpointCSIDriverName = constants.DriverName
+)
+
+const (
+	Requeue     = true
+	DontRequeue = false
+)
 
 // A Reconciler reconciles Mountpoint Pods by watching other workload Pods that's using S3 CSI Driver.
 type Reconciler struct {
@@ -47,7 +60,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // Reconcile reconciles either a Mountpoint- or a workload-Pod.
 //
 // For Mountpoint Pods, it deletes completed Pods and logs each status change.
-// For workload Pods, it decides if it needs to spawn a Mountpoint Pod to provide a volume for the workload Pod.
+// For workload Pods, it decides if it needs to spawn a Mountpoint/Headroom Pod to provide a volume for the workload Pod.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx).WithValues("pod", req.NamespacedName)
 
@@ -60,11 +73,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			log.Info("Pod not found - ignoring")
 			return reconcile.Result{}, nil
 		}
-		log.Error(err, "failed to get Pod")
+		log.Error(err, "Failed to get Pod")
 		return reconcile.Result{}, err
 	}
 
-	if r.isMountpointPod(pod) {
+	if r.isInMountpointNamespace(pod) {
 		return r.reconcileMountpointPod(ctx, pod)
 	}
 
@@ -83,7 +96,7 @@ func (r *Reconciler) reconcileMountpointPod(ctx context.Context, pod *corev1.Pod
 	case corev1.PodSucceeded:
 		err := r.deleteMountpointPod(ctx, pod)
 		if err != nil {
-			log.Error(err, "failed to delete succeeded Pod")
+			log.Error(err, "Failed to delete succeeded Pod")
 			return reconcile.Result{}, err
 		}
 		log.Info("Pod succeeded and successfully deleted")
@@ -101,20 +114,56 @@ func (r *Reconciler) reconcileMountpointPod(ctx context.Context, pod *corev1.Pod
 func (r *Reconciler) reconcileWorkloadPod(ctx context.Context, pod *corev1.Pod) (reconcile.Result, error) {
 	log := logf.FromContext(ctx).WithValues("pod", types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 
-	if pod.Spec.NodeName == "" {
-		log.V(debugLevel).Info("Pod is not scheduled to a node yet - ignoring")
-		return reconcile.Result{}, nil
-	}
-
 	if len(pod.Spec.Volumes) == 0 {
 		log.V(debugLevel).Info("Pod has no volumes - ignoring")
 		return reconcile.Result{}, nil
 	}
 
-	var requeue bool
+	scheduled := isPodScheduled(pod)
+	if !scheduled {
+		log.V(debugLevel).Info("Pod is not scheduled to a node yet - ignoring")
+		return reconcile.Result{}, nil
+	}
+
+	volumes, requeue, err := r.getWorkloadVolumes(ctx, pod)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	var errs []error
 
-	for _, vol := range pod.Spec.Volumes {
+	for _, vol := range volumes {
+		pv, pvc := vol.pv, vol.pvc
+
+		log.V(debugLevel).Info("Found bound PV for PVC", "pvc", pvc.Name, "volumeName", pv.Name)
+
+		needsRequeue, err := r.spawnOrDeleteMountpointPodIfNeeded(ctx, pod, pvc, pv)
+		requeue = requeue || needsRequeue
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	err = errors.Join(errs...)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{Requeue: requeue}, nil
+}
+
+// getWorkloadVolumes returns list of volumes of the workload that ready to process.
+func (r *Reconciler) getWorkloadVolumes(
+	ctx context.Context,
+	workloadPod *corev1.Pod,
+) ([]*workloadVolume, bool, error) {
+	status := DontRequeue
+
+	var errs []error
+	var volumes []*workloadVolume
+
+	for _, vol := range workloadPod.Spec.Volumes {
 		podPVC := vol.PersistentVolumeClaim
 		if podPVC == nil {
 			continue
@@ -123,10 +172,10 @@ func (r *Reconciler) reconcileWorkloadPod(ctx context.Context, pod *corev1.Pod) 
 		// If PVC has no bound PVs yet, `getBoundPVForPodClaim` will return `errPVCIsNotBoundToAPV`.
 		// In this case we'll just return `reconcile.Result{Requeue: true}` here, which will bubble up to the
 		// original `Reconcile` call and will cause a retry for this Pod with an exponential backoff.
-		pvc, pv, err := r.getBoundPVForPodClaim(ctx, pod, podPVC)
+		pvc, pv, err := r.getBoundPVForPodClaim(ctx, workloadPod, podPVC)
 		if err != nil {
 			if errors.Is(err, errPVCIsNotBoundToAPV) {
-				requeue = true
+				status = Requeue
 			} else {
 				errs = append(errs, err)
 			}
@@ -138,16 +187,17 @@ func (r *Reconciler) reconcileWorkloadPod(ctx context.Context, pod *corev1.Pod) 
 			continue
 		}
 
-		log.V(debugLevel).Info("Found bound PV for PVC", "pvc", pvc.Name, "volumeName", pv.Name)
-
-		err = r.spawnOrDeleteMountpointPodIfNeeded(ctx, pod, pvc, pv, csiSpec)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
+		volumes = append(volumes, &workloadVolume{pv, pvc, csiSpec})
 	}
 
-	return reconcile.Result{Requeue: requeue}, errors.Join(errs...)
+	return volumes, status, errors.Join(errs...)
+}
+
+// A workloadVolume represents a workload's volume backed by the CSI Driver.
+type workloadVolume struct {
+	pv      *corev1.PersistentVolume
+	pvc     *corev1.PersistentVolumeClaim
+	csiSpec *corev1.CSIPersistentVolumeSource
 }
 
 // spawnOrDeleteMountpointPodIfNeeded spawns or deletes existing Mountpoint Pod for given `workloadPod` and volume if needed.
@@ -163,57 +213,375 @@ func (r *Reconciler) spawnOrDeleteMountpointPodIfNeeded(
 	workloadPod *corev1.Pod,
 	pvc *corev1.PersistentVolumeClaim,
 	pv *corev1.PersistentVolume,
-	csiSpec *corev1.CSIPersistentVolumeSource,
-) error {
-	mpPodName := mppod.MountpointPodNameFor(string(workloadPod.UID), pvc.Spec.VolumeName)
+) (bool, error) {
+	workloadUID := string(workloadPod.UID)
+	fieldFilters := r.buildFieldFilters(workloadPod, pv)
+	s3pa, err := r.getExistingS3PodAttachment(ctx, fieldFilters)
+	if err != nil {
+		return Requeue, err
+	}
+	log := r.setupLogger(ctx, workloadPod, pvc, workloadUID, fieldFilters, s3pa)
 
-	log := logf.FromContext(ctx).WithValues(
-		"workloadPod", types.NamespacedName{Namespace: workloadPod.Namespace, Name: workloadPod.Name},
-		"mountpointPod", mpPodName,
-		"pvc", pvc.Name, "volumeName", pv.Name)
-
-	mpPod := &corev1.Pod{}
-	err := r.Get(ctx, types.NamespacedName{Namespace: r.mountpointPodConfig.Namespace, Name: mpPodName}, mpPod)
-	if err != nil && !apierrors.IsNotFound(err) {
-		log.Error(err, "failed to get Mountpoint Pod")
-		return err
+	if !isPodActive(workloadPod) {
+		return r.handleInactivePod(ctx, s3pa, workloadUID, log)
 	}
 
-	isMountpointPodExists := err == nil
+	if s3pa != nil {
+		return r.handleExistingS3PodAttachment(ctx, workloadPod, pv, s3pa, log)
+	} else {
+		return r.handleNewS3PodAttachment(ctx, workloadPod, pv, log)
+	}
+}
 
-	// `workloadPod` is not active, its either terminated (i.e., `phase == Succeeded or phase == failed`) or
-	// its scheduled for termination (i.e., `DeletionTimestamp != nil`)
-	if !isPodActive(workloadPod) {
-		// if its scheduled for termination and its still in `Pending` phase,
-		// delete if there is an existing Mountpoint Pod as otherwise this
-		// Mountpoint Pod might take some time to terminate on its own.
-		if isMountpointPodExists && workloadPod.Status.Phase == corev1.PodPending {
-			log.Info("Deleting scheduled Mountpoint Pod")
-			err := r.deleteMountpointPod(ctx, mpPod)
-			if err != nil {
-				log.Error(err, "failed to delete scheduled Mountpoint Pod")
-				return err
-			}
+// setupLogger creates and configures logger that includes pod namespace/name, PVC name, and workload UID fields.
+// If an S3PodAttachment is provided, its name is added. All fieldFilters are appended as additional key-value pairs.
+func (r *Reconciler) setupLogger(
+	ctx context.Context,
+	workloadPod *corev1.Pod,
+	pvc *corev1.PersistentVolumeClaim,
+	workloadUID string,
+	fieldFilters client.MatchingFields,
+	s3pa *crdv2.MountpointS3PodAttachment,
+) logr.Logger {
+	logger := logf.FromContext(ctx).WithValues(
+		"workloadPod", types.NamespacedName{Namespace: workloadPod.Namespace, Name: workloadPod.Name},
+		"pvc", pvc.Name,
+		"workloadUID", workloadUID,
+	)
 
-			log.Info("Scheduled Mountpoint Pod deleted")
-			return err
+	if s3pa != nil {
+		logger = logger.WithValues("s3pa", s3pa.Name)
+	}
+
+	var keyValues []interface{}
+	for k, v := range fieldFilters {
+		keyValues = append(keyValues, k, v)
+	}
+
+	if len(keyValues) > 0 {
+		logger = logger.WithValues(keyValues...)
+	}
+
+	return logger
+}
+
+// buildFieldFilters build appropriate matching field filters for List operation on MountpointS3PodAttachments
+func (r *Reconciler) buildFieldFilters(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) client.MatchingFields {
+	fsGroup := r.getFSGroup(workloadPod)
+
+	fieldFilters := client.MatchingFields{
+		crdv2.FieldNodeName:             workloadPod.Spec.NodeName,
+		crdv2.FieldPersistentVolumeName: pv.Name,
+		crdv2.FieldVolumeID:             pv.Spec.CSI.VolumeHandle,
+		crdv2.FieldMountOptions:         strings.Join(pv.Spec.MountOptions, ","),
+		crdv2.FieldWorkloadFSGroup:      fsGroup,
+	}
+
+	return fieldFilters
+}
+
+// getFSGroup returns the FSGroup value from the pod's security context as a string.
+// If FSGroup is not set, it returns an empty string.
+func (r *Reconciler) getFSGroup(workloadPod *corev1.Pod) string {
+	if workloadPod.Spec.SecurityContext != nil && workloadPod.Spec.SecurityContext.FSGroup != nil {
+		return strconv.FormatInt(*workloadPod.Spec.SecurityContext.FSGroup, 10)
+	}
+	return ""
+}
+
+// getExistingS3PodAttachment retrieves a MountpointS3PodAttachment resource that matches the provided field filters.
+// It returns:
+// - The matching MountpointS3PodAttachment if exactly one is found
+// - nil if no matching resource is found
+// - An error if multiple matching resources are found or if the list operation fails
+func (r *Reconciler) getExistingS3PodAttachment(ctx context.Context, fieldFilters client.MatchingFields) (*crdv2.MountpointS3PodAttachment, error) {
+	s3paList := &crdv2.MountpointS3PodAttachmentList{}
+	if err := r.List(ctx, s3paList, fieldFilters); err != nil {
+		return nil, fmt.Errorf("failed to list MountpointS3PodAttachments: %w", err)
+	}
+
+	switch len(s3paList.Items) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &s3paList.Items[0], nil
+	default:
+		return nil, fmt.Errorf("found %d MountpointS3PodAttachments when expecting 0 or 1", len(s3paList.Items))
+	}
+}
+
+// handleInactivePod handles inactive workload pod.
+func (r *Reconciler) handleInactivePod(ctx context.Context, s3pa *crdv2.MountpointS3PodAttachment, workloadUID string, log logr.Logger) (bool, error) {
+	if s3pa == nil {
+		log.Info("Workload pod is not active. Did not find any MountpointS3PodAttachments.")
+		return DontRequeue, nil
+	}
+
+	return r.removeWorkloadFromS3PodAttachment(ctx, s3pa, workloadUID, log)
+}
+
+// handleExistingS3PodAttachment handles existing S3 Pod Attachment.
+func (r *Reconciler) handleExistingS3PodAttachment(
+	ctx context.Context,
+	workloadPod *corev1.Pod,
+	pv *corev1.PersistentVolume,
+	s3pa *crdv2.MountpointS3PodAttachment,
+	log logr.Logger,
+) (bool, error) {
+	if s3paContainsWorkload(s3pa, string(workloadPod.UID)) {
+		log.Info("MountpointS3PodAttachment already has this workload UID")
+		return DontRequeue, nil
+	}
+
+	return r.addWorkloadToS3PodAttachment(ctx, workloadPod, pv, s3pa, log)
+}
+
+// addWorkloadToS3PodAttachment adds workload UID to the first suitable Mountpoint Pod in the map.
+// If there aren't any suitable Mountpoint Pods, it creates a new one and assign the workload UID to that Mountpoint Pod.
+func (r *Reconciler) addWorkloadToS3PodAttachment(
+	ctx context.Context,
+	workloadPod *corev1.Pod,
+	pv *corev1.PersistentVolume,
+	s3pa *crdv2.MountpointS3PodAttachment,
+	log logr.Logger,
+) (bool, error) {
+	log.Info("Adding workload UID to MountpointS3PodAttachment")
+
+	shouldRequeue, err := r.assignWorkloadToAnExistingMountpointPod(ctx, s3pa, string(workloadPod.UID), log)
+	if err == nil {
+		// Successfully assigned workload to an existing Mountpoint Pod
+		return shouldRequeue, nil
+	}
+
+	if !errors.Is(err, errNoSuitableMountpointPodForTheWorkload) {
+		// We got an error other than there is no suitable Mountpoint Pod for the workload, just propagate it
+		return Requeue, err
+	}
+
+	// There is no suitable Mountpoint Pod for the workload, we need to create a new one
+	mpPod, err := r.spawnMountpointPod(ctx, workloadPod, pv, log)
+	if err != nil {
+		log.Error(err, "Failed to spawn Mountpoint Pod")
+		return Requeue, err
+	}
+	s3pa.Spec.MountpointS3PodAttachments[mpPod.Name] = []crdv2.WorkloadAttachment{
+		{
+			WorkloadPodUID: string(workloadPod.UID),
+			AttachmentTime: metav1.NewTime(time.Now().UTC()),
+		},
+	}
+	err = r.Update(ctx, s3pa)
+	if err != nil {
+		log.Error(err, "Failed to update MountpointS3PodAttachment, deleting spawned Mountpoint Pod", "mountpointPodName", mpPod.Name)
+
+		// Clean up spawned Mountpoint Pod
+		if deleteErr := r.Delete(ctx, mpPod); deleteErr != nil {
+			log.Error(deleteErr, "Failed to cleanup Mountpoint Pod after MountpointS3PodAttachment update failure", "mountpointPodName", mpPod.Name)
+		} else {
+			log.Info("Successfully cleaned up Mountpoint Pod after S3PodAttachment update failure", "mountpointPodName", mpPod.Name)
 		}
 
-		// No need to do anything - either there was no Mountpoint Pod for `pod` or it was in `Running` state,
-		// so a clean unmount operation will be performed and Mountpoint Pod will cleany exit (and get deleted by `reconcileMountpointPod`).
-		return nil
+		if apierrors.IsConflict(err) {
+			log.Info("Failed to update MountpointS3PodAttachment - resource conflict - requeue")
+			return Requeue, nil
+		}
+
+		return Requeue, err
 	}
 
-	if isMountpointPodExists {
-		log.V(debugLevel).Info("Mountpoint Pod already exists - ignoring")
-		return nil
+	log.Info("A new Mountpoint Pod is successfully created for the workload and MountpointS3PodAttachment is successfully updated", "mountpointPodName", mpPod.Name)
+
+	return DontRequeue, nil
+}
+
+// errNoSuitableMountpointPodForTheWorkload is returned when there isn't any suitable Mountpoint Pod to assign the workload
+// to indicate that a new Mountpoint Pod should be created to assign the workload for.
+var errNoSuitableMountpointPodForTheWorkload = errors.New("no suitable Mountpoint Pod found for the workload")
+
+// assignWorkloadToAnExistingMountpointPod tries to assign given `workloadUID` to an existing Mountpoint Pod.
+// It returns `errNoSuitableMountpointPodForTheWorkload` if there isn't any suitable Mountpoint Pod to assign this new workload.
+func (r *Reconciler) assignWorkloadToAnExistingMountpointPod(ctx context.Context, s3pa *crdv2.MountpointS3PodAttachment, workloadUID string, log logr.Logger) (bool, error) {
+	log.Info("Trying to assign workload to an existing Mountpoint Pod")
+
+	found := false
+
+	for mpPodName := range s3pa.Spec.MountpointS3PodAttachments {
+		mpPodLog := log.WithValues("mountpointPodName", mpPodName)
+		mpPod, err := r.getMountpointPod(ctx, mpPodName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				mpPodLog.Info("Mountpoint Pod is not found - not suitable for assigning new workload")
+				continue
+			}
+			return Requeue, err
+		}
+
+		if !r.shouldAssignNewWorkloadToMountpointPod(mpPod, mpPodLog) {
+			mpPodLog.Info("Mountpoint Pod is not suitable for assigning new workload")
+			continue
+		}
+
+		s3pa.Spec.MountpointS3PodAttachments[mpPodName] = append(s3pa.Spec.MountpointS3PodAttachments[mpPodName], crdv2.WorkloadAttachment{
+			WorkloadPodUID: workloadUID,
+			AttachmentTime: metav1.NewTime(time.Now().UTC()),
+		})
+		found = true
+		mpPodLog.Info("Found a suitable Mountpoint Pod to assign new workload")
+		break
 	}
 
-	if err := r.spawnMountpointPod(ctx, workloadPod, pvc, pv, csiSpec, mpPodName); err != nil {
-		log.Error(err, "failed to spawn Mountpoint Pod")
+	if !found {
+		return DontRequeue, errNoSuitableMountpointPodForTheWorkload
+	}
+
+	err := r.Update(ctx, s3pa)
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			log.Info("Failed to update MountpointS3PodAttachment - resource conflict - requeue")
+			return Requeue, nil
+		}
+		log.Error(err, "Failed to update MountpointS3PodAttachment")
+		return Requeue, err
+	}
+
+	return DontRequeue, nil
+}
+
+// removeWorkloadFromS3PodAttachment removes workload UID from MountpointS3PodAttachment map.
+// It will delete MountpointS3PodAttachment if map becomes empty.
+func (r *Reconciler) removeWorkloadFromS3PodAttachment(ctx context.Context, s3pa *crdv2.MountpointS3PodAttachment, workloadUID string, log logr.Logger) (bool, error) {
+	// Remove workload UID from mountpoint pods
+	for mpPodName, attachments := range s3pa.Spec.MountpointS3PodAttachments {
+		filteredUIDs := []crdv2.WorkloadAttachment{}
+		found := false
+		for _, attachment := range attachments {
+			if attachment.WorkloadPodUID == workloadUID {
+				found = true
+				continue
+			}
+			filteredUIDs = append(filteredUIDs, attachment)
+		}
+		if found {
+			s3pa.Spec.MountpointS3PodAttachments[mpPodName] = filteredUIDs
+			err := r.Update(ctx, s3pa)
+			if err != nil {
+				if apierrors.IsConflict(err) {
+					log.Info("Failed to remove workload pod UID from existing MountpointS3PodAttachment due to resource conflict, requeuing")
+					return Requeue, nil
+				}
+				log.Error(err, "Failed to update MountpointS3PodAttachment")
+				return Requeue, err
+			}
+			log.Info("Successfully removed workload pod UID from MountpointS3PodAttachment")
+			break
+		}
+	}
+
+	// Remove Mountpoint pods with zero workloads
+	for mpPodName, uids := range s3pa.Spec.MountpointS3PodAttachments {
+		if len(uids) == 0 {
+			log.Info("Mountpoint pod has zero workload UIDs. Adding "+mppod.AnnotationNeedsUnmount+" annotation",
+				"mountpointPodName", mpPodName)
+			err := r.addNeedsUnmountAnnotation(ctx, mpPodName, log)
+			if err != nil {
+				return Requeue, err
+			}
+
+			log.Info("Mountpoint pod has zero workload UIDs. Will remove it from MountpointS3PodAttachment",
+				"mountpointPodName", mpPodName)
+			delete(s3pa.Spec.MountpointS3PodAttachments, mpPodName)
+			err = r.Update(ctx, s3pa)
+			if err != nil {
+				if apierrors.IsConflict(err) {
+					log.Info("Failed to remove Mountpoint pod from MountpointS3PodAttachment due to resource conflict, requeuing",
+						"mountpointPodName", mpPodName)
+					return Requeue, nil
+				}
+				log.Error(err, "Failed to update MountpointS3PodAttachment")
+				return Requeue, err
+			}
+		}
+	}
+
+	// Delete MountpointS3PodAttachment if map is empty
+	if len(s3pa.Spec.MountpointS3PodAttachments) == 0 {
+		log.Info("MountpointS3PodAttachment has zero Mountpoint Pods. Will delete it")
+		err := r.Delete(ctx, s3pa)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				log.Info("Failed to delete MountpointS3PodAttachment due to resource conflict, requeuing")
+				return Requeue, nil
+			}
+			log.Error(err, "Failed to delete MountpointS3PodAttachment")
+			return Requeue, err
+		}
+	}
+
+	return DontRequeue, nil
+}
+
+// handleNewS3PodAttachment handles new S3 pod attachment in case none were found.
+func (r *Reconciler) handleNewS3PodAttachment(
+	ctx context.Context,
+	workloadPod *corev1.Pod,
+	pv *corev1.PersistentVolume,
+	log logr.Logger,
+) (bool, error) {
+	if isPodRunning(workloadPod) {
+		// Kubernetes guarantees that all volumes were successfully mounted when a pod is Running.
+		log.Info("Workload pod is already in Running phase and MountpointS3PodAttachment does not exist. " +
+			"This means the S3 volume was already mounted by something else (likely systemd-based mount from CSI Driver v1). " +
+			"Skipping creation of MountpointS3PodAttachment and Mountpoint Pod.")
+		return DontRequeue, nil
+	}
+
+	if err := r.createS3PodAttachmentWithMPPod(ctx, workloadPod, pv, log); err != nil {
+		return Requeue, err
+	}
+
+	return DontRequeue, nil
+}
+
+// createS3PodAttachmentWithMPPod creates new MountpointS3PodAttachment resource and Mountpoint Pod for given workload and PV.
+func (r *Reconciler) createS3PodAttachmentWithMPPod(
+	ctx context.Context,
+	workloadPod *corev1.Pod,
+	pv *corev1.PersistentVolume,
+	log logr.Logger,
+) error {
+	mpPod, err := r.spawnMountpointPod(ctx, workloadPod, pv, log)
+	if err != nil {
+		log.Error(err, "Failed to spawn Mountpoint Pod")
+		return err
+	}
+	s3pa := &crdv2.MountpointS3PodAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "s3pa-",
+		},
+		Spec: crdv2.MountpointS3PodAttachmentSpec{
+			NodeName:             workloadPod.Spec.NodeName,
+			PersistentVolumeName: pv.Name,
+			VolumeID:             pv.Spec.CSI.VolumeHandle,
+			MountOptions:         strings.Join(pv.Spec.MountOptions, ","),
+			WorkloadFSGroup:      r.getFSGroup(workloadPod),
+			MountpointS3PodAttachments: map[string][]crdv2.WorkloadAttachment{
+				mpPod.Name: {{WorkloadPodUID: string(workloadPod.UID), AttachmentTime: metav1.NewTime(time.Now().UTC())}},
+			},
+		},
+	}
+
+	err = r.Create(ctx, s3pa)
+	if err != nil {
+		log.Error(err, "Failed to create MountpointS3PodAttachment")
+		if deleteErr := r.Delete(ctx, mpPod); deleteErr != nil {
+			log.Error(deleteErr, "Failed to cleanup Mountpoint Pod after MountpointS3PodAttachment creation failure", "mountpointPodName", mpPod.Name)
+		} else {
+			log.Info("Successfully cleaned up Mountpoint Pod after S3PodAttachment creation failure", "mountpointPodName", mpPod.Name)
+		}
 		return err
 	}
 
+	log.Info("MountpointS3PodAttachment is created", "s3pa", s3pa.Name)
 	return nil
 }
 
@@ -223,33 +591,20 @@ func (r *Reconciler) spawnOrDeleteMountpointPodIfNeeded(
 func (r *Reconciler) spawnMountpointPod(
 	ctx context.Context,
 	workloadPod *corev1.Pod,
-	pvc *corev1.PersistentVolumeClaim,
 	pv *corev1.PersistentVolume,
-	_ *corev1.CSIPersistentVolumeSource,
-	name string,
-) error {
-	log := logf.FromContext(ctx).WithValues(
-		"workloadPod", types.NamespacedName{Namespace: workloadPod.Namespace, Name: workloadPod.Name},
-		"mountpointPod", name,
-		"pvc", pvc.Name, "volumeName", pv.Name)
-
+	log logr.Logger,
+) (*corev1.Pod, error) {
 	log.Info("Spawning Mountpoint Pod")
 
 	mpPod := r.mountpointPodCreator.Create(workloadPod, pv)
-	if mpPod.Name != name {
-		err := fmt.Errorf("mountpoint Pod name mismatch %s vs %s", mpPod.Name, name)
-		log.Error(err, "Name mismatch on Mountpoint Pod")
-		return err
-	}
 
 	err := r.Create(ctx, mpPod)
 	if err != nil {
-		log.Error(err, "failed to create Mountpoint Pod")
-		return err
+		return nil, err
 	}
 
-	log.Info("Mountpoint Pod spawned", "mountpointPodUID", mpPod.UID)
-	return nil
+	log.Info("Mountpoint Pod spawned", "mountpointPodName", mpPod.Name)
+	return mpPod, nil
 }
 
 // deleteMountpointPod deletes given `mountpointPod`.
@@ -268,8 +623,78 @@ func (r *Reconciler) deleteMountpointPod(ctx context.Context, mountpointPod *cor
 		return nil
 	}
 
-	log.Error(err, "failed to delete Mountpoint Pod")
+	log.Error(err, "Failed to delete Mountpoint Pod")
 	return err
+}
+
+// getMountpointPod tries to find Mountpoint Pod with given `name`.
+func (r *Reconciler) getMountpointPod(ctx context.Context, name string) (*corev1.Pod, error) {
+	mpPod := &corev1.Pod{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: r.mountpointPodConfig.Namespace, Name: name}, mpPod)
+	if err != nil {
+		return nil, err
+	}
+	return mpPod, nil
+}
+
+// shouldAssignNewWorkloadToMountpointPod returns whether a new workload should be assigned to the Mountpoint Pod `mpPod`.
+func (r *Reconciler) shouldAssignNewWorkloadToMountpointPod(mpPod *corev1.Pod, log logr.Logger) bool {
+	if mpPod.Annotations != nil {
+		if mpPod.Annotations[mppod.AnnotationNeedsUnmount] == "true" {
+			log.Info("Mountpoint Pod is annotated as 'needs-unmount' - not suitable for a new workload")
+			return false
+		}
+
+		if mpPod.Annotations[mppod.AnnotationNoNewWorkload] == "true" {
+			log.Info("Mountpoint Pod is annotated as 'no-new-workload' - not suitable for a new workload")
+			return false
+		}
+	}
+
+	if mpPod.Labels != nil {
+		if mpPod.Labels[mppod.LabelCSIDriverVersion] != r.mountpointPodConfig.CSIDriverVersion {
+			log.Info("Mountpoint Pod is created with a different CSI Driver version - not suitable for a new workload",
+				"mountpointPodCreatedByCSIDriverVersion", mpPod.Labels[mppod.LabelCSIDriverVersion],
+				"currentCSIDriverVersion", r.mountpointPodConfig.CSIDriverVersion)
+			return false
+		}
+	}
+
+	return true
+}
+
+// addNeedsUnmountAnnotation add "s3.csi.scality.com/needs-unmount" to Mountpoint Pod.
+// This will trigger CSI Driver Node to cleanly unmount and Mountpoint Pod will become 'Succeeded'.
+func (r *Reconciler) addNeedsUnmountAnnotation(ctx context.Context, mpPodName string, log logr.Logger) error {
+	// Get the pod
+	mpPod, err := r.getMountpointPod(ctx, mpPodName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Failed to find Mountpoint Pod - ignoring")
+			return nil
+		}
+		log.Error(err, "Failed to get Pod")
+		return err
+	}
+
+	if mpPod.Annotations == nil {
+		mpPod.Annotations = make(map[string]string)
+	}
+	mpPod.Annotations[mppod.AnnotationNeedsUnmount] = "true"
+
+	// Update the pod
+	err = r.Update(ctx, mpPod) // TODO: This probably needs to be a patch as we might've get a stale Mountpoint Pod.
+	if err != nil {
+		log.Error(err, "Failed to update Mountpoint Pod")
+		return err
+	}
+
+	return nil
+}
+
+// isInMountpointNamespace returns whether given `pod` is in the Mountpoint namespace.
+func (r *Reconciler) isInMountpointNamespace(pod *corev1.Pod) bool {
+	return pod.Namespace == r.mountpointPodConfig.Namespace
 }
 
 // errPVCIsNotBoundToAPV is returned when given PVC is not bound to a PV yet.
@@ -289,7 +714,7 @@ func (r *Reconciler) getBoundPVForPodClaim(
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: claim.ClaimName}, pvc)
 	if err != nil {
-		log.Error(err, "failed to get PVC for Pod")
+		log.Error(err, "Failed to get PVC for Pod")
 		return nil, nil, fmt.Errorf("failed to get PVC for Pod: %w", err)
 	}
 
@@ -303,7 +728,7 @@ func (r *Reconciler) getBoundPVForPodClaim(
 	pv := &corev1.PersistentVolume{}
 	err = r.Get(ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv)
 	if err != nil {
-		log.Error(err, "failed to get PV bound to PVC", "volumeName", pvc.Spec.VolumeName)
+		log.Error(err, "Failed to get PV bound to PVC", "volumeName", pvc.Spec.VolumeName)
 		return nil, nil, fmt.Errorf("failed to get PV bound to PVC: %w", err)
 	}
 
@@ -313,13 +738,6 @@ func (r *Reconciler) getBoundPVForPodClaim(
 	}
 
 	return pvc, pv, nil
-}
-
-// isMountpointPod returns whether given `pod` is a Mountpoint Pod.
-// It currently checks namespace of `pod`.
-func (r *Reconciler) isMountpointPod(pod *corev1.Pod) bool {
-	// TODO: Do we need to perform any additional check here?
-	return pod.Namespace == r.mountpointPodConfig.Namespace
 }
 
 // extractCSISpecFromPV tries to extract `CSIPersistentVolumeSource` from given `pv`.
@@ -332,10 +750,32 @@ func extractCSISpecFromPV(pv *corev1.PersistentVolume) *corev1.CSIPersistentVolu
 	return csi
 }
 
-// isPodActive returns whether given Pod is active and not in the process of termination.
+// isPodActive returns whether given the Pod is active and not in the process of termination.
 // Copied from https://github.com/kubernetes/kubernetes/blob/8770bd58d04555303a3a15b30c245a58723d0f4a/pkg/controller/controller_utils.go#L1009-L1013.
 func isPodActive(p *corev1.Pod) bool {
 	return corev1.PodSucceeded != p.Status.Phase &&
 		corev1.PodFailed != p.Status.Phase &&
 		p.DeletionTimestamp == nil
+}
+
+// isPodScheduled returns whether the given Pod is scheduled.
+func isPodScheduled(p *corev1.Pod) bool {
+	return p.Spec.NodeName != ""
+}
+
+// isPodRunning returns whether given Pod phase is `Running`.
+func isPodRunning(p *corev1.Pod) bool {
+	return p.Status.Phase == corev1.PodRunning
+}
+
+// s3paContainsWorkload checks whether MountpointS3PodAttachment has `workloadUID` in it.
+func s3paContainsWorkload(s3pa *crdv2.MountpointS3PodAttachment, workloadUID string) bool {
+	for _, attachments := range s3pa.Spec.MountpointS3PodAttachments {
+		for _, attachment := range attachments {
+			if attachment.WorkloadPodUID == workloadUID {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/scality-csi-controller/main.go
+++ b/cmd/scality-csi-controller/main.go
@@ -11,6 +11,9 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -18,19 +21,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/scality/mountpoint-s3-csi-driver/cmd/scality-csi-controller/csicontroller"
+	crdv2 "github.com/scality/mountpoint-s3-csi-driver/pkg/api/v2"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/cluster"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/version"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
 )
 
 var (
-	mountpointNamespace         = flag.String("mountpoint-namespace", os.Getenv("MOUNTPOINT_NAMESPACE"), "Namespace to spawn Mountpoint Pods in.")
-	mountpointVersion           = flag.String("mountpoint-version", os.Getenv("MOUNTPOINT_VERSION"), "Version of Mountpoint within the given Mountpoint image.")
-	mountpointPriorityClassName = flag.String("mountpoint-priority-class-name", os.Getenv("MOUNTPOINT_PRIORITY_CLASS_NAME"), "Priority class name of the Mountpoint Pods.")
-	mountpointImage             = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
-	mountpointImagePullPolicy   = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
-	mountpointContainerCommand  = flag.String("mountpoint-container-command", "/bin/scality-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
+	mountpointNamespace                   = flag.String("mountpoint-namespace", os.Getenv("MOUNTPOINT_NAMESPACE"), "Namespace to spawn Mountpoint Pods in.")
+	mountpointVersion                     = flag.String("mountpoint-version", os.Getenv("MOUNTPOINT_VERSION"), "Version of Mountpoint within the given Mountpoint image.")
+	mountpointPriorityClassName           = flag.String("mountpoint-priority-class-name", os.Getenv("MOUNTPOINT_PRIORITY_CLASS_NAME"), "Priority class name of the Mountpoint Pods.")
+	mountpointPreemptingPriorityClassName = flag.String("mountpoint-preempting-priority-class-name", os.Getenv("MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME"), "Preempting priority class name of the Mountpoint Pods.")
+	mountpointHeadroomPriorityClassName   = flag.String("mountpoint-headroom-priority-class-name", os.Getenv("MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME"), "Priority class name of the Headroom Pods.")
+	mountpointImage                       = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
+	headroomImage                         = flag.String("headroom-image", os.Getenv("MOUNTPOINT_HEADROOM_IMAGE"), "Image of a pause container to use in spawned Headroom Pods.")
+	mountpointImagePullPolicy             = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
+	mountpointContainerCommand            = flag.String("mountpoint-container-command", "/bin/scality-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
 )
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(crdv2.AddToScheme(scheme))
+}
 
 func main() {
 	flag.Parse()
@@ -38,28 +52,42 @@ func main() {
 	logf.SetLogger(zap.New())
 
 	log := logf.Log.WithName(csicontroller.Name)
-	client := config.GetConfigOrDie()
+	conf := config.GetConfigOrDie()
 
-	mgr, err := manager.New(client, manager.Options{})
+	mgr, err := manager.New(conf, manager.Options{
+		Scheme: scheme,
+	})
 	if err != nil {
 		log.Error(err, "failed to create a new manager")
 		os.Exit(1)
 	}
 
-	err = csicontroller.NewReconciler(mgr.GetClient(), mppod.Config{
-		Namespace:         *mountpointNamespace,
-		MountpointVersion: *mountpointVersion,
-		PriorityClassName: *mountpointPriorityClassName,
+	// Setup field indexers for MountpointS3PodAttachment CRDs
+	if err := crdv2.SetupManagerIndices(mgr); err != nil {
+		log.Error(err, "failed to setup field indexers")
+		os.Exit(1)
+	}
+
+	podConfig := mppod.Config{
+		Namespace:                   *mountpointNamespace,
+		MountpointVersion:           *mountpointVersion,
+		PriorityClassName:           *mountpointPriorityClassName,
+		PreemptingPriorityClassName: *mountpointPreemptingPriorityClassName,
+		HeadroomPriorityClassName:   *mountpointHeadroomPriorityClassName,
 		Container: mppod.ContainerConfig{
 			Command:         *mountpointContainerCommand,
 			Image:           *mountpointImage,
+			HeadroomImage:   *headroomImage,
 			ImagePullPolicy: corev1.PullPolicy(*mountpointImagePullPolicy),
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,
-		ClusterVariant:   cluster.DetectVariant(client, log),
-	}).SetupWithManager(mgr)
+		ClusterVariant:   cluster.DetectVariant(conf, log),
+	}
+
+	// Setup the pod reconciler that will create MountpointS3PodAttachments
+	err = csicontroller.NewReconciler(mgr.GetClient(), podConfig).SetupWithManager(mgr)
 	if err != nil {
-		log.Error(err, "failed to create controller")
+		log.Error(err, "failed to create pod reconciler")
 		os.Exit(1)
 	}
 

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -7,6 +7,12 @@ const (
 
 	MountpointPodServiceAccountName = "mountpointPodServiceAccountName"
 
+	// Resource configuration for Mountpoint containers
+	MountpointContainerResourcesRequestsCpu    = "mountpointContainerResourcesRequestsCpu"
+	MountpointContainerResourcesRequestsMemory = "mountpointContainerResourcesRequestsMemory"
+	MountpointContainerResourcesLimitsCpu      = "mountpointContainerResourcesLimitsCpu"
+	MountpointContainerResourcesLimitsMemory   = "mountpointContainerResourcesLimitsMemory"
+
 	CSIServiceAccountName   = "csi.storage.k8s.io/serviceAccount.name"
 	CSIServiceAccountTokens = "csi.storage.k8s.io/serviceAccount.tokens"
 	CSIPodNamespace         = "csi.storage.k8s.io/pod.namespace"

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -1,0 +1,172 @@
+package mppod
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
+)
+
+// Labels populated on spawned Headroom Pods.
+const (
+	LabelHeadroomForPod    = constants.DriverName + "/headroom-for-pod"
+	LabelHeadroomForVolume = constants.DriverName + "/headroom-for-volume"
+)
+
+// Labels populated on Workload Pods requesting Headroom Pods.
+const (
+	LabelHeadroomForWorkload = constants.DriverName + "/headroom-for-workload"
+)
+
+// A scheduling gate can be used on Workload Pods using a volume backed by the CSI Driver to signal the CSI Driver
+// to reserve headroom for the Mountpoint Pod to serve volumes to workload.
+//
+// If this scheduling gate is used on a Workload Pod, the CSI Driver:
+//  1. Labels the Workload Pod to use inter-pod affinity rules in the Headroom Pods
+//  2. Creates Headroom Pods using a pause container with inter-pod affinity rule to the Workload Pod
+//  3. Ungates the scheduling gate from the Workload Pod to let it scheduled - alongside the Headroom Pods if possible
+//  4. Schedules Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod) into the same node as the Workload and Headroom Pods using a preempting priority class
+//  5. Mountpoint Pod most likely preempts the Headroom Pods if there is no space in the node - as the Headroom Pods uses a negative priority -, or just gets scheduled if there is enough space for all pods
+//  6. Deletes the Headroom Pods as soon as the Workload Pod is running or terminated - as Mountpoint Pods are already scheduled or no longer needed
+const SchedulingGateReserveHeadroomForMountpointPod = constants.DriverName + "/reserve-headroom-for-mppod"
+
+const headroomPodNamePrefix = "hr-"
+
+// HeadroomPod returns a new Headroom Pod spec for the given `workloadPod` and `pv`.
+// This Headroom Pod serves as a capacity headroom to allow scheduling of the Mountpoint Pod alongside `workloadPod` to provide volume for `pv`.
+func (c *Creator) HeadroomPod(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) (*corev1.Pod, error) {
+	hrPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HeadroomPodNameFor(workloadPod, pv),
+			Namespace: c.config.Namespace,
+			Labels: map[string]string{
+				LabelHeadroomForPod:    string(workloadPod.UID),
+				LabelHeadroomForVolume: pv.Name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			PriorityClassName: c.config.HeadroomPriorityClassName,
+			Affinity: &corev1.Affinity{
+				// Specify inter-pod affinity rule to Workload Pod to
+				// ensure they're co-scheduled into the same node.
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      LabelHeadroomForWorkload,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{string(workloadPod.UID)},
+									},
+								},
+							},
+							Namespaces:  []string{workloadPod.Namespace},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: c.config.Container.HeadroomImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+				},
+			},
+			Tolerations: []corev1.Toleration{
+				// Tolerate all taints, so this Headroom Pod would be scheduled to any node alongside the Workload Pod.
+				{Operator: corev1.TolerationOpExists},
+			},
+		},
+	}
+
+	hrContainer := &hrPod.Spec.Containers[0]
+	volumeAttributes := ExtractVolumeAttributes(pv)
+
+	if err := c.configureResourceRequests(hrContainer, volumeAttributes); err != nil {
+		return nil, err
+	}
+	if err := c.configureResourceLimits(hrContainer, volumeAttributes); err != nil {
+		return nil, err
+	}
+
+	return hrPod, nil
+}
+
+// HeadroomPodNameFor returns a consistent name for the Headroom Pod for given `workloadPod` and `pv`.
+func HeadroomPodNameFor(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) string {
+	return fmt.Sprintf("%s%x", headroomPodNamePrefix, sha256.Sum224(fmt.Appendf(nil, "%s%s", workloadPod.UID, pv.Name)))
+}
+
+// IsHeadroomPod returns whether given pod is a Headroom Pod.
+//
+// Note that, this function doesn't check the namespace, it's caller's responsibility to ensure
+// the pod queried is in the correct namespace for Headroom Pods.
+func IsHeadroomPod(pod *corev1.Pod) bool {
+	return strings.HasPrefix(pod.Name, headroomPodNamePrefix)
+}
+
+// LabelWorkloadPodForHeadroomPod adds [LabelHeadroomForWorkload] label to the `workloadPod`
+// in order to use in inter-pod affinity rules in the Headroom Pod.
+//
+// It returns whether label added.
+func LabelWorkloadPodForHeadroomPod(workloadPod *corev1.Pod) bool {
+	if WorkloadHasLabelPodForHeadroomPod(workloadPod) {
+		return false
+	}
+
+	if workloadPod.Labels == nil {
+		workloadPod.Labels = make(map[string]string)
+	}
+	workloadPod.Labels[LabelHeadroomForWorkload] = string(workloadPod.UID)
+	return true
+}
+
+// WorkloadHasLabelPodForHeadroomPod returns whether the `workloadPod` is labelled with [LabelHeadroomForWorkload].
+func WorkloadHasLabelPodForHeadroomPod(workloadPod *corev1.Pod) bool {
+	return workloadPod.Labels != nil &&
+		workloadPod.Labels[LabelHeadroomForWorkload] != ""
+}
+
+// UnlabelWorkloadPodForHeadroomPod removes [LabelHeadroomForWorkload] label from the `workloadPod`.
+//
+// It returns whether label removed.
+func UnlabelWorkloadPodForHeadroomPod(workloadPod *corev1.Pod) bool {
+	if !WorkloadHasLabelPodForHeadroomPod(workloadPod) {
+		return false
+	}
+
+	delete(workloadPod.Labels, LabelHeadroomForWorkload)
+	return true
+}
+
+// ShouldReserveHeadroomForMountpointPod returns whether the `workloadPod` wants to reserve headroom for a Mountpoint Pod.
+func ShouldReserveHeadroomForMountpointPod(workloadPod *corev1.Pod) bool {
+	return slices.ContainsFunc(workloadPod.Spec.SchedulingGates, isHeadroomSchedulingGate)
+}
+
+// UngateHeadroomSchedulingGateForWorkloadPod removes the [SchedulingGateReserveHeadroomForMountpointPod] scheduling gate from the `workloadPod`.
+func UngateHeadroomSchedulingGateForWorkloadPod(workloadPod *corev1.Pod) {
+	workloadPod.Spec.SchedulingGates = slices.DeleteFunc(workloadPod.Spec.SchedulingGates, isHeadroomSchedulingGate)
+}
+
+// isHeadroomSchedulingGate returns whether the `sg` equals to [SchedulingGateReserveHeadroomForMountpointPod].
+func isHeadroomSchedulingGate(sg corev1.PodSchedulingGate) bool {
+	return sg.Name == SchedulingGateReserveHeadroomForMountpointPod
+}

--- a/pkg/podmounter/mppod/headroom_test.go
+++ b/pkg/podmounter/mppod/headroom_test.go
@@ -1,0 +1,708 @@
+package mppod_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/cluster"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/volumecontext"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name             string
+		volumeAttributes map[string]string
+		expectError      bool
+		expectedErrorMsg string
+		verifyPod        func(t *testing.T, pod *corev1.Pod)
+	}{
+		{
+			name: "basic headroom pod creation",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod == nil {
+					t.Fatal("Expected pod to not be nil")
+				}
+				assert.Equals(t, "mount-s3", pod.Namespace)
+				assert.Equals(t, "headroom-priority", pod.Spec.PriorityClassName)
+				assert.Equals(t, 1, len(pod.Spec.Containers))
+				assert.Equals(t, "pause", pod.Spec.Containers[0].Name)
+				assert.Equals(t, "pause-image:latest", pod.Spec.Containers[0].Image)
+			},
+		},
+		{
+			name: "with resource requests",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesRequestsCpu:    "100m",
+				volumecontext.MountpointContainerResourcesRequestsMemory: "256Mi",
+			},
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod == nil {
+					t.Fatal("Expected pod to not be nil")
+				}
+				container := &pod.Spec.Containers[0]
+				if container.Resources.Requests == nil {
+					t.Fatal("Expected container.Resources.Requests to not be nil")
+				}
+				assert.Equals(t, resource.MustParse("100m"), container.Resources.Requests[corev1.ResourceCPU])
+				assert.Equals(t, resource.MustParse("256Mi"), container.Resources.Requests[corev1.ResourceMemory])
+			},
+		},
+		{
+			name: "with resource limits",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesLimitsCpu:    "500m",
+				volumecontext.MountpointContainerResourcesLimitsMemory: "1Gi",
+			},
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod == nil {
+					t.Fatal("Expected pod to not be nil")
+				}
+				container := &pod.Spec.Containers[0]
+				if container.Resources.Limits == nil {
+					t.Fatal("Expected container.Resources.Limits to not be nil")
+				}
+				assert.Equals(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+				assert.Equals(t, resource.MustParse("1Gi"), container.Resources.Limits[corev1.ResourceMemory])
+			},
+		},
+		{
+			name: "with invalid cpu request",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesRequestsCpu: "invalid-cpu",
+			},
+			expectError:      true,
+			expectedErrorMsg: "failed to parse quantity \"invalid-cpu\"",
+		},
+		{
+			name: "with invalid memory limit",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesLimitsMemory: "invalid-mem",
+			},
+			expectError:      true,
+			expectedErrorMsg: "failed to parse quantity \"invalid-mem\"",
+		},
+		{
+			name: "verify affinity rules",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod.Spec.Affinity == nil {
+					t.Fatal("Expected pod.Spec.Affinity to not be nil")
+				}
+				if pod.Spec.Affinity.PodAffinity == nil {
+					t.Fatal("Expected pod.Spec.Affinity.PodAffinity to not be nil")
+				}
+				assert.Equals(t, 1, len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+
+				term := pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+				assert.Equals(t, "kubernetes.io/hostname", term.TopologyKey)
+				assert.Equals(t, []string{"test-namespace"}, term.Namespaces)
+
+				if term.LabelSelector == nil {
+					t.Fatal("Expected term.LabelSelector to not be nil")
+				}
+				assert.Equals(t, 1, len(term.LabelSelector.MatchExpressions))
+				expr := term.LabelSelector.MatchExpressions[0]
+				assert.Equals(t, mppod.LabelHeadroomForWorkload, expr.Key)
+				assert.Equals(t, metav1.LabelSelectorOpIn, expr.Operator)
+				assert.Equals(t, []string{"workload-pod-uid"}, expr.Values)
+			},
+		},
+		{
+			name: "verify security context",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				container := &pod.Spec.Containers[0]
+				if container.SecurityContext == nil {
+					t.Fatal("Expected container.SecurityContext to not be nil")
+				}
+				assert.Equals(t, ptr.To(false), container.SecurityContext.AllowPrivilegeEscalation)
+				assert.Equals(t, ptr.To(true), container.SecurityContext.RunAsNonRoot)
+				if container.SecurityContext.Capabilities == nil {
+					t.Fatal("Expected container.SecurityContext.Capabilities to not be nil")
+				}
+				assert.Equals(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
+				if container.SecurityContext.SeccompProfile == nil {
+					t.Fatal("Expected container.SecurityContext.SeccompProfile to not be nil")
+				}
+				assert.Equals(t, corev1.SeccompProfileTypeRuntimeDefault, container.SecurityContext.SeccompProfile.Type)
+			},
+		},
+		{
+			name: "verify tolerations",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				assert.Equals(t, 1, len(pod.Spec.Tolerations))
+				assert.Equals(t, corev1.TolerationOpExists, pod.Spec.Tolerations[0].Operator)
+			},
+		},
+		{
+			name: "verify labels",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod.Labels == nil {
+					t.Fatal("Expected pod.Labels to not be nil")
+				}
+				assert.Equals(t, "workload-pod-uid", pod.Labels[mppod.LabelHeadroomForPod])
+				assert.Equals(t, "test-pv", pod.Labels[mppod.LabelHeadroomForVolume])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := mppod.Config{
+				Namespace:                 "mount-s3",
+				HeadroomPriorityClassName: "headroom-priority",
+				Container: mppod.ContainerConfig{
+					HeadroomImage: "pause-image:latest",
+				},
+				ClusterVariant: cluster.DefaultKubernetes,
+			}
+
+			creator := mppod.NewCreator(config)
+
+			workloadPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "workload-pod",
+					Namespace: "test-namespace",
+					UID:       types.UID("workload-pod-uid"),
+				},
+			}
+
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: tc.volumeAttributes,
+						},
+					},
+				},
+			}
+
+			pod, err := creator.HeadroomPod(workloadPod, pv)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+				if tc.expectedErrorMsg != "" && !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tc.expectedErrorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, got %v", err)
+				}
+				if tc.verifyPod != nil {
+					tc.verifyPod(t, pod)
+				}
+			}
+		})
+	}
+}
+
+func TestHeadroomPodNameFor(t *testing.T) {
+	testCases := []struct {
+		name         string
+		workloadUID  string
+		pvName       string
+		expectedName string
+	}{
+		{
+			name:         "standard pod and pv",
+			workloadUID:  "pod-123",
+			pvName:       "pv-456",
+			expectedName: "hr-4a9703f375169c248f447afc10bed9459a12ded40eccd3104835ed3e",
+		},
+		{
+			name:         "empty uid",
+			workloadUID:  "",
+			pvName:       "pv-789",
+			expectedName: "hr-21739e0f8b2f3fda07bec18d48da2e8255b957504f32d311bd39cbee",
+		},
+		{
+			name:         "empty pv name",
+			workloadUID:  "pod-abc",
+			pvName:       "",
+			expectedName: "hr-e1d6cb42b532365443b43e5708daf02cc9799fad4c8d37e53e32192c",
+		},
+		{
+			name:         "both empty",
+			workloadUID:  "",
+			pvName:       "",
+			expectedName: "hr-d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
+		},
+		{
+			name:         "consistent hashing",
+			workloadUID:  "test-uid",
+			pvName:       "test-pv",
+			expectedName: "hr-aae734ade8800262147c73f5dffabd7f293cbd616b5ffd7066914a58",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			workloadPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID(tc.workloadUID),
+				},
+			}
+
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.pvName,
+				},
+			}
+
+			name := mppod.HeadroomPodNameFor(workloadPod, pv)
+			assert.Equals(t, tc.expectedName, name)
+
+			// Verify consistency - calling again should return same name
+			name2 := mppod.HeadroomPodNameFor(workloadPod, pv)
+			assert.Equals(t, name, name2)
+		})
+	}
+}
+
+func TestIsHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name       string
+		podName    string
+		isHeadroom bool
+	}{
+		{
+			name:       "valid headroom pod",
+			podName:    "hr-abc123",
+			isHeadroom: true,
+		},
+		{
+			name:       "valid headroom pod with long hash",
+			podName:    "hr-d0f23a1ff0ad96e4cf087a2aa04b54f09a456b926b87f49b9b93c72c",
+			isHeadroom: true,
+		},
+		{
+			name:       "not a headroom pod - different prefix",
+			podName:    "mp-abc123",
+			isHeadroom: false,
+		},
+		{
+			name:       "not a headroom pod - no prefix",
+			podName:    "abc123",
+			isHeadroom: false,
+		},
+		{
+			name:       "edge case - hr without dash",
+			podName:    "hrabc123",
+			isHeadroom: false,
+		},
+		{
+			name:       "edge case - just hr-",
+			podName:    "hr-",
+			isHeadroom: true,
+		},
+		{
+			name:       "empty name",
+			podName:    "",
+			isHeadroom: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.podName,
+				},
+			}
+
+			result := mppod.IsHeadroomPod(pod)
+			assert.Equals(t, tc.isHeadroom, result)
+		})
+	}
+}
+
+func TestLabelWorkloadPodForHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialLabels map[string]string
+		expectAdded   bool
+	}{
+		{
+			name:          "add label to pod without labels",
+			initialLabels: nil,
+			expectAdded:   true,
+		},
+		{
+			name:          "add label to pod with existing labels",
+			initialLabels: map[string]string{"existing": "label"},
+			expectAdded:   true,
+		},
+		{
+			name:          "label already exists",
+			initialLabels: map[string]string{mppod.LabelHeadroomForWorkload: "existing-uid"},
+			expectAdded:   false,
+		},
+		{
+			name:          "empty map",
+			initialLabels: map[string]string{},
+			expectAdded:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:    types.UID("test-uid-123"),
+					Labels: tc.initialLabels,
+				},
+			}
+
+			added := mppod.LabelWorkloadPodForHeadroomPod(pod)
+			assert.Equals(t, tc.expectAdded, added)
+
+			// Verify label is set correctly
+			if pod.Labels == nil {
+				t.Fatal("Expected pod.Labels to not be nil")
+			}
+			if tc.expectAdded {
+				assert.Equals(t, "test-uid-123", pod.Labels[mppod.LabelHeadroomForWorkload])
+			}
+
+			// Verify existing labels are preserved
+			if tc.initialLabels != nil {
+				for k, v := range tc.initialLabels {
+					if k != mppod.LabelHeadroomForWorkload || !tc.expectAdded {
+						assert.Equals(t, v, pod.Labels[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestWorkloadHasLabelPodForHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		labels   map[string]string
+		hasLabel bool
+	}{
+		{
+			name:     "has label",
+			labels:   map[string]string{mppod.LabelHeadroomForWorkload: "some-uid"},
+			hasLabel: true,
+		},
+		{
+			name:     "no label",
+			labels:   map[string]string{"other": "label"},
+			hasLabel: false,
+		},
+		{
+			name:     "empty label value",
+			labels:   map[string]string{mppod.LabelHeadroomForWorkload: ""},
+			hasLabel: false,
+		},
+		{
+			name:     "nil labels",
+			labels:   nil,
+			hasLabel: false,
+		},
+		{
+			name:     "empty map",
+			labels:   map[string]string{},
+			hasLabel: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.labels,
+				},
+			}
+
+			result := mppod.WorkloadHasLabelPodForHeadroomPod(pod)
+			assert.Equals(t, tc.hasLabel, result)
+		})
+	}
+}
+
+func TestUnlabelWorkloadPodForHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name           string
+		initialLabels  map[string]string
+		expectRemoved  bool
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "remove existing label",
+			initialLabels:  map[string]string{mppod.LabelHeadroomForWorkload: "uid-123", "other": "label"},
+			expectRemoved:  true,
+			expectedLabels: map[string]string{"other": "label"},
+		},
+		{
+			name:           "label doesn't exist",
+			initialLabels:  map[string]string{"other": "label"},
+			expectRemoved:  false,
+			expectedLabels: map[string]string{"other": "label"},
+		},
+		{
+			name:           "empty label value",
+			initialLabels:  map[string]string{mppod.LabelHeadroomForWorkload: ""},
+			expectRemoved:  false,
+			expectedLabels: map[string]string{mppod.LabelHeadroomForWorkload: ""},
+		},
+		{
+			name:          "nil labels",
+			initialLabels: nil,
+			expectRemoved: false,
+		},
+		{
+			name:           "only headroom label",
+			initialLabels:  map[string]string{mppod.LabelHeadroomForWorkload: "uid"},
+			expectRemoved:  true,
+			expectedLabels: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.initialLabels,
+				},
+			}
+
+			removed := mppod.UnlabelWorkloadPodForHeadroomPod(pod)
+			assert.Equals(t, tc.expectRemoved, removed)
+
+			// Verify expected labels
+			if tc.expectedLabels != nil {
+				if pod.Labels == nil {
+					t.Fatal("Expected pod.Labels to not be nil")
+				}
+				assert.Equals(t, len(tc.expectedLabels), len(pod.Labels))
+				for k, v := range tc.expectedLabels {
+					assert.Equals(t, v, pod.Labels[k])
+				}
+			}
+		})
+	}
+}
+
+func TestShouldReserveHeadroomForMountpointPod(t *testing.T) {
+	testCases := []struct {
+		name            string
+		schedulingGates []corev1.PodSchedulingGate
+		shouldReserve   bool
+	}{
+		{
+			name: "has headroom scheduling gate",
+			schedulingGates: []corev1.PodSchedulingGate{
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+			},
+			shouldReserve: true,
+		},
+		{
+			name: "has headroom scheduling gate among others",
+			schedulingGates: []corev1.PodSchedulingGate{
+				{Name: "other-gate"},
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+				{Name: "another-gate"},
+			},
+			shouldReserve: true,
+		},
+		{
+			name: "no headroom scheduling gate",
+			schedulingGates: []corev1.PodSchedulingGate{
+				{Name: "other-gate"},
+			},
+			shouldReserve: false,
+		},
+		{
+			name:            "no scheduling gates",
+			schedulingGates: nil,
+			shouldReserve:   false,
+		},
+		{
+			name:            "empty scheduling gates",
+			schedulingGates: []corev1.PodSchedulingGate{},
+			shouldReserve:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: tc.schedulingGates,
+				},
+			}
+
+			result := mppod.ShouldReserveHeadroomForMountpointPod(pod)
+			assert.Equals(t, tc.shouldReserve, result)
+		})
+	}
+}
+
+func TestUngateHeadroomSchedulingGateForWorkloadPod(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		initialSchedulingGates  []corev1.PodSchedulingGate
+		expectedSchedulingGates []corev1.PodSchedulingGate
+	}{
+		{
+			name: "remove headroom gate only",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{},
+		},
+		{
+			name: "remove headroom gate among others",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+				{Name: "gate2"},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: "gate2"},
+			},
+		},
+		{
+			name: "no headroom gate to remove",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: "gate2"},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: "gate2"},
+			},
+		},
+		{
+			name:                    "no scheduling gates",
+			initialSchedulingGates:  nil,
+			expectedSchedulingGates: nil,
+		},
+		{
+			name: "multiple headroom gates",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+				{Name: "middle"},
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "middle"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: tc.initialSchedulingGates,
+				},
+			}
+
+			mppod.UngateHeadroomSchedulingGateForWorkloadPod(pod)
+
+			if tc.expectedSchedulingGates == nil {
+				if pod.Spec.SchedulingGates != nil {
+					t.Errorf("Expected pod.Spec.SchedulingGates to be nil, got %v", pod.Spec.SchedulingGates)
+				}
+			} else {
+				if pod.Spec.SchedulingGates == nil {
+					t.Fatal("Expected pod.Spec.SchedulingGates to not be nil")
+				}
+				assert.Equals(t, len(tc.expectedSchedulingGates), len(pod.Spec.SchedulingGates))
+				for i, gate := range tc.expectedSchedulingGates {
+					assert.Equals(t, gate.Name, pod.Spec.SchedulingGates[i].Name)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractVolumeAttributes(t *testing.T) {
+	testCases := []struct {
+		name               string
+		pv                 *corev1.PersistentVolume
+		expectedAttributes map[string]string
+	}{
+		{
+			name: "pv with volume attributes",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: map[string]string{
+								"key1": "value1",
+								"key2": "value2",
+							},
+						},
+					},
+				},
+			},
+			expectedAttributes: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "pv without CSI spec",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{},
+			},
+			expectedAttributes: map[string]string{},
+		},
+		{
+			name: "pv with nil volume attributes",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: nil,
+						},
+					},
+				},
+			},
+			expectedAttributes: map[string]string{},
+		},
+		{
+			name: "pv with empty volume attributes",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: map[string]string{},
+						},
+					},
+				},
+			},
+			expectedAttributes: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mppod.ExtractVolumeAttributes(tc.pv)
+			if result == nil {
+				t.Fatal("ExtractVolumeAttributes should never return nil")
+			}
+			assert.Equals(t, len(tc.expectedAttributes), len(result))
+			for k, v := range tc.expectedAttributes {
+				assert.Equals(t, v, result[k])
+			}
+		})
+	}
+}

--- a/pkg/podmounter/mppod/mppod.go
+++ b/pkg/podmounter/mppod/mppod.go
@@ -4,6 +4,22 @@ package mppod
 import (
 	"crypto/sha256"
 	"fmt"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
+)
+
+// Pod annotations
+const (
+	// AnnotationNeedsUnmount is the annotation used to mark a pod for unmounting
+	AnnotationNeedsUnmount = constants.DriverName + "/needs-unmount"
+	// AnnotationNoNewWorkload is the annotation used to prevent new workloads from being assigned
+	AnnotationNoNewWorkload = constants.DriverName + "/no-new-workload"
+)
+
+// Pod labels
+const (
+	// LabelVolumeId is the label used to store the volume ID
+	LabelVolumeId = constants.DriverName + "/volume-id"
 )
 
 // MountpointPodNameFor returns a consistent and unique Pod name for


### PR DESCRIPTION
- Implement reconciliation loop for MountpointS3PodAttachment
- Add PV and workload pod lookup functionality
- Configure environment variables for pod creation
- Set up dual container mode for controller
- Add complete RBAC permissions for CRD and pod management

Issue: S3CSI-172

Tests failing are expected, will be solved in future PRs