### PR TITLE
S3CSI-175: Add headroom pod scheduling optimization

### DIFF
--- a/cmd/scality-csi-controller/main.go
+++ b/cmd/scality-csi-controller/main.go
@@ -11,6 +11,9 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -18,19 +21,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/scality/mountpoint-s3-csi-driver/cmd/scality-csi-controller/csicontroller"
+	crdv2 "github.com/scality/mountpoint-s3-csi-driver/pkg/api/v2"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/cluster"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/version"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
 )
 
 var (
-	mountpointNamespace         = flag.String("mountpoint-namespace", os.Getenv("MOUNTPOINT_NAMESPACE"), "Namespace to spawn Mountpoint Pods in.")
-	mountpointVersion           = flag.String("mountpoint-version", os.Getenv("MOUNTPOINT_VERSION"), "Version of Mountpoint within the given Mountpoint image.")
-	mountpointPriorityClassName = flag.String("mountpoint-priority-class-name", os.Getenv("MOUNTPOINT_PRIORITY_CLASS_NAME"), "Priority class name of the Mountpoint Pods.")
-	mountpointImage             = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
-	mountpointImagePullPolicy   = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
-	mountpointContainerCommand  = flag.String("mountpoint-container-command", "/bin/scality-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
+	mountpointNamespace                   = flag.String("mountpoint-namespace", os.Getenv("MOUNTPOINT_NAMESPACE"), "Namespace to spawn Mountpoint Pods in.")
+	mountpointVersion                     = flag.String("mountpoint-version", os.Getenv("MOUNTPOINT_VERSION"), "Version of Mountpoint within the given Mountpoint image.")
+	mountpointPriorityClassName           = flag.String("mountpoint-priority-class-name", os.Getenv("MOUNTPOINT_PRIORITY_CLASS_NAME"), "Priority class name of the Mountpoint Pods.")
+	mountpointPreemptingPriorityClassName = flag.String("mountpoint-preempting-priority-class-name", os.Getenv("MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME"), "Preempting priority class name of the Mountpoint Pods.")
+	mountpointHeadroomPriorityClassName   = flag.String("mountpoint-headroom-priority-class-name", os.Getenv("MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME"), "Priority class name of the Headroom Pods.")
+	mountpointImage                       = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
+	headroomImage                         = flag.String("headroom-image", os.Getenv("MOUNTPOINT_HEADROOM_IMAGE"), "Image of a pause container to use in spawned Headroom Pods.")
+	mountpointImagePullPolicy             = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
+	mountpointContainerCommand            = flag.String("mountpoint-container-command", "/bin/scality-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
 )
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(crdv2.AddToScheme(scheme))
+}
 
 func main() {
 	flag.Parse()
@@ -38,28 +52,42 @@ func main() {
 	logf.SetLogger(zap.New())
 
 	log := logf.Log.WithName(csicontroller.Name)
-	client := config.GetConfigOrDie()
+	conf := config.GetConfigOrDie()
 
-	mgr, err := manager.New(client, manager.Options{})
+	mgr, err := manager.New(conf, manager.Options{
+		Scheme: scheme,
+	})
 	if err != nil {
 		log.Error(err, "failed to create a new manager")
 		os.Exit(1)
 	}
 
-	err = csicontroller.NewReconciler(mgr.GetClient(), mppod.Config{
-		Namespace:         *mountpointNamespace,
-		MountpointVersion: *mountpointVersion,
-		PriorityClassName: *mountpointPriorityClassName,
+	// Setup field indexers for MountpointS3PodAttachment CRDs
+	if err := crdv2.SetupManagerIndices(mgr); err != nil {
+		log.Error(err, "failed to setup field indexers")
+		os.Exit(1)
+	}
+
+	podConfig := mppod.Config{
+		Namespace:                   *mountpointNamespace,
+		MountpointVersion:           *mountpointVersion,
+		PriorityClassName:           *mountpointPriorityClassName,
+		PreemptingPriorityClassName: *mountpointPreemptingPriorityClassName,
+		HeadroomPriorityClassName:   *mountpointHeadroomPriorityClassName,
 		Container: mppod.ContainerConfig{
 			Command:         *mountpointContainerCommand,
 			Image:           *mountpointImage,
+			HeadroomImage:   *headroomImage,
 			ImagePullPolicy: corev1.PullPolicy(*mountpointImagePullPolicy),
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,
-		ClusterVariant:   cluster.DetectVariant(client, log),
-	}).SetupWithManager(mgr)
+		ClusterVariant:   cluster.DetectVariant(conf, log),
+	}
+
+	// Setup the pod reconciler that will create MountpointS3PodAttachments
+	err = csicontroller.NewReconciler(mgr.GetClient(), podConfig).SetupWithManager(mgr)
 	if err != nil {
-		log.Error(err, "failed to create controller")
+		log.Error(err, "failed to create pod reconciler")
 		os.Exit(1)
 	}
 

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -1,0 +1,172 @@
+package mppod
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/constants"
+)
+
+// Labels populated on spawned Headroom Pods.
+const (
+	LabelHeadroomForPod    = constants.DriverName + "/headroom-for-pod"
+	LabelHeadroomForVolume = constants.DriverName + "/headroom-for-volume"
+)
+
+// Labels populated on Workload Pods requesting Headroom Pods.
+const (
+	LabelHeadroomForWorkload = constants.DriverName + "/headroom-for-workload"
+)
+
+// A scheduling gate can be used on Workload Pods using a volume backed by the CSI Driver to signal the CSI Driver
+// to reserve headroom for the Mountpoint Pod to serve volumes to workload.
+//
+// If this scheduling gate is used on a Workload Pod, the CSI Driver:
+//  1. Labels the Workload Pod to use inter-pod affinity rules in the Headroom Pods
+//  2. Creates Headroom Pods using a pause container with inter-pod affinity rule to the Workload Pod
+//  3. Ungates the scheduling gate from the Workload Pod to let it scheduled - alongside the Headroom Pods if possible
+//  4. Schedules Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod) into the same node as the Workload and Headroom Pods using a preempting priority class
+//  5. Mountpoint Pod most likely preempts the Headroom Pods if there is no space in the node - as the Headroom Pods uses a negative priority -, or just gets scheduled if there is enough space for all pods
+//  6. Deletes the Headroom Pods as soon as the Workload Pod is running or terminated - as Mountpoint Pods are already scheduled or no longer needed
+const SchedulingGateReserveHeadroomForMountpointPod = constants.DriverName + "/reserve-headroom-for-mppod"
+
+const headroomPodNamePrefix = "hr-"
+
+// HeadroomPod returns a new Headroom Pod spec for the given `workloadPod` and `pv`.
+// This Headroom Pod serves as a capacity headroom to allow scheduling of the Mountpoint Pod alongside `workloadPod` to provide volume for `pv`.
+func (c *Creator) HeadroomPod(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) (*corev1.Pod, error) {
+	hrPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HeadroomPodNameFor(workloadPod, pv),
+			Namespace: c.config.Namespace,
+			Labels: map[string]string{
+				LabelHeadroomForPod:    string(workloadPod.UID),
+				LabelHeadroomForVolume: pv.Name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			PriorityClassName: c.config.HeadroomPriorityClassName,
+			Affinity: &corev1.Affinity{
+				// Specify inter-pod affinity rule to Workload Pod to
+				// ensure they're co-scheduled into the same node.
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      LabelHeadroomForWorkload,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{string(workloadPod.UID)},
+									},
+								},
+							},
+							Namespaces:  []string{workloadPod.Namespace},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: c.config.Container.HeadroomImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+				},
+			},
+			Tolerations: []corev1.Toleration{
+				// Tolerate all taints, so this Headroom Pod would be scheduled to any node alongside the Workload Pod.
+				{Operator: corev1.TolerationOpExists},
+			},
+		},
+	}
+
+	hrContainer := &hrPod.Spec.Containers[0]
+	volumeAttributes := ExtractVolumeAttributes(pv)
+
+	if err := c.configureResourceRequests(hrContainer, volumeAttributes); err != nil {
+		return nil, err
+	}
+	if err := c.configureResourceLimits(hrContainer, volumeAttributes); err != nil {
+		return nil, err
+	}
+
+	return hrPod, nil
+}
+
+// HeadroomPodNameFor returns a consistent name for the Headroom Pod for given `workloadPod` and `pv`.
+func HeadroomPodNameFor(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) string {
+	return fmt.Sprintf("%s%x", headroomPodNamePrefix, sha256.Sum224(fmt.Appendf(nil, "%s%s", workloadPod.UID, pv.Name)))
+}
+
+// IsHeadroomPod returns whether given pod is a Headroom Pod.
+//
+// Note that, this function doesn't check the namespace, it's caller's responsibility to ensure
+// the pod queried is in the correct namespace for Headroom Pods.
+func IsHeadroomPod(pod *corev1.Pod) bool {
+	return strings.HasPrefix(pod.Name, headroomPodNamePrefix)
+}
+
+// LabelWorkloadPodForHeadroomPod adds [LabelHeadroomForWorkload] label to the `workloadPod`
+// in order to use in inter-pod affinity rules in the Headroom Pod.
+//
+// It returns whether label added.
+func LabelWorkloadPodForHeadroomPod(workloadPod *corev1.Pod) bool {
+	if WorkloadHasLabelPodForHeadroomPod(workloadPod) {
+		return false
+	}
+
+	if workloadPod.Labels == nil {
+		workloadPod.Labels = make(map[string]string)
+	}
+	workloadPod.Labels[LabelHeadroomForWorkload] = string(workloadPod.UID)
+	return true
+}
+
+// WorkloadHasLabelPodForHeadroomPod returns whether the `workloadPod` is labelled with [LabelHeadroomForWorkload].
+func WorkloadHasLabelPodForHeadroomPod(workloadPod *corev1.Pod) bool {
+	return workloadPod.Labels != nil &&
+		workloadPod.Labels[LabelHeadroomForWorkload] != ""
+}
+
+// UnlabelWorkloadPodForHeadroomPod removes [LabelHeadroomForWorkload] label from the `workloadPod`.
+//
+// It returns whether label removed.
+func UnlabelWorkloadPodForHeadroomPod(workloadPod *corev1.Pod) bool {
+	if !WorkloadHasLabelPodForHeadroomPod(workloadPod) {
+		return false
+	}
+
+	delete(workloadPod.Labels, LabelHeadroomForWorkload)
+	return true
+}
+
+// ShouldReserveHeadroomForMountpointPod returns whether the `workloadPod` wants to reserve headroom for a Mountpoint Pod.
+func ShouldReserveHeadroomForMountpointPod(workloadPod *corev1.Pod) bool {
+	return slices.ContainsFunc(workloadPod.Spec.SchedulingGates, isHeadroomSchedulingGate)
+}
+
+// UngateHeadroomSchedulingGateForWorkloadPod removes the [SchedulingGateReserveHeadroomForMountpointPod] scheduling gate from the `workloadPod`.
+func UngateHeadroomSchedulingGateForWorkloadPod(workloadPod *corev1.Pod) {
+	workloadPod.Spec.SchedulingGates = slices.DeleteFunc(workloadPod.Spec.SchedulingGates, isHeadroomSchedulingGate)
+}
+
+// isHeadroomSchedulingGate returns whether the `sg` equals to [SchedulingGateReserveHeadroomForMountpointPod].
+func isHeadroomSchedulingGate(sg corev1.PodSchedulingGate) bool {
+	return sg.Name == SchedulingGateReserveHeadroomForMountpointPod
+}

--- a/pkg/podmounter/mppod/headroom_test.go
+++ b/pkg/podmounter/mppod/headroom_test.go
@@ -1,0 +1,708 @@
+package mppod_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/cluster"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/driver/node/volumecontext"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/scality/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name             string
+		volumeAttributes map[string]string
+		expectError      bool
+		expectedErrorMsg string
+		verifyPod        func(t *testing.T, pod *corev1.Pod)
+	}{
+		{
+			name: "basic headroom pod creation",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod == nil {
+					t.Fatal("Expected pod to not be nil")
+				}
+				assert.Equals(t, "mount-s3", pod.Namespace)
+				assert.Equals(t, "headroom-priority", pod.Spec.PriorityClassName)
+				assert.Equals(t, 1, len(pod.Spec.Containers))
+				assert.Equals(t, "pause", pod.Spec.Containers[0].Name)
+				assert.Equals(t, "pause-image:latest", pod.Spec.Containers[0].Image)
+			},
+		},
+		{
+			name: "with resource requests",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesRequestsCpu:    "100m",
+				volumecontext.MountpointContainerResourcesRequestsMemory: "256Mi",
+			},
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod == nil {
+					t.Fatal("Expected pod to not be nil")
+				}
+				container := &pod.Spec.Containers[0]
+				if container.Resources.Requests == nil {
+					t.Fatal("Expected container.Resources.Requests to not be nil")
+				}
+				assert.Equals(t, resource.MustParse("100m"), container.Resources.Requests[corev1.ResourceCPU])
+				assert.Equals(t, resource.MustParse("256Mi"), container.Resources.Requests[corev1.ResourceMemory])
+			},
+		},
+		{
+			name: "with resource limits",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesLimitsCpu:    "500m",
+				volumecontext.MountpointContainerResourcesLimitsMemory: "1Gi",
+			},
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod == nil {
+					t.Fatal("Expected pod to not be nil")
+				}
+				container := &pod.Spec.Containers[0]
+				if container.Resources.Limits == nil {
+					t.Fatal("Expected container.Resources.Limits to not be nil")
+				}
+				assert.Equals(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+				assert.Equals(t, resource.MustParse("1Gi"), container.Resources.Limits[corev1.ResourceMemory])
+			},
+		},
+		{
+			name: "with invalid cpu request",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesRequestsCpu: "invalid-cpu",
+			},
+			expectError:      true,
+			expectedErrorMsg: "failed to parse quantity \"invalid-cpu\"",
+		},
+		{
+			name: "with invalid memory limit",
+			volumeAttributes: map[string]string{
+				volumecontext.MountpointContainerResourcesLimitsMemory: "invalid-mem",
+			},
+			expectError:      true,
+			expectedErrorMsg: "failed to parse quantity \"invalid-mem\"",
+		},
+		{
+			name: "verify affinity rules",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod.Spec.Affinity == nil {
+					t.Fatal("Expected pod.Spec.Affinity to not be nil")
+				}
+				if pod.Spec.Affinity.PodAffinity == nil {
+					t.Fatal("Expected pod.Spec.Affinity.PodAffinity to not be nil")
+				}
+				assert.Equals(t, 1, len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+
+				term := pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+				assert.Equals(t, "kubernetes.io/hostname", term.TopologyKey)
+				assert.Equals(t, []string{"test-namespace"}, term.Namespaces)
+
+				if term.LabelSelector == nil {
+					t.Fatal("Expected term.LabelSelector to not be nil")
+				}
+				assert.Equals(t, 1, len(term.LabelSelector.MatchExpressions))
+				expr := term.LabelSelector.MatchExpressions[0]
+				assert.Equals(t, mppod.LabelHeadroomForWorkload, expr.Key)
+				assert.Equals(t, metav1.LabelSelectorOpIn, expr.Operator)
+				assert.Equals(t, []string{"workload-pod-uid"}, expr.Values)
+			},
+		},
+		{
+			name: "verify security context",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				container := &pod.Spec.Containers[0]
+				if container.SecurityContext == nil {
+					t.Fatal("Expected container.SecurityContext to not be nil")
+				}
+				assert.Equals(t, ptr.To(false), container.SecurityContext.AllowPrivilegeEscalation)
+				assert.Equals(t, ptr.To(true), container.SecurityContext.RunAsNonRoot)
+				if container.SecurityContext.Capabilities == nil {
+					t.Fatal("Expected container.SecurityContext.Capabilities to not be nil")
+				}
+				assert.Equals(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
+				if container.SecurityContext.SeccompProfile == nil {
+					t.Fatal("Expected container.SecurityContext.SeccompProfile to not be nil")
+				}
+				assert.Equals(t, corev1.SeccompProfileTypeRuntimeDefault, container.SecurityContext.SeccompProfile.Type)
+			},
+		},
+		{
+			name: "verify tolerations",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				assert.Equals(t, 1, len(pod.Spec.Tolerations))
+				assert.Equals(t, corev1.TolerationOpExists, pod.Spec.Tolerations[0].Operator)
+			},
+		},
+		{
+			name: "verify labels",
+			verifyPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod.Labels == nil {
+					t.Fatal("Expected pod.Labels to not be nil")
+				}
+				assert.Equals(t, "workload-pod-uid", pod.Labels[mppod.LabelHeadroomForPod])
+				assert.Equals(t, "test-pv", pod.Labels[mppod.LabelHeadroomForVolume])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := mppod.Config{
+				Namespace:                 "mount-s3",
+				HeadroomPriorityClassName: "headroom-priority",
+				Container: mppod.ContainerConfig{
+					HeadroomImage: "pause-image:latest",
+				},
+				ClusterVariant: cluster.DefaultKubernetes,
+			}
+
+			creator := mppod.NewCreator(config)
+
+			workloadPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "workload-pod",
+					Namespace: "test-namespace",
+					UID:       types.UID("workload-pod-uid"),
+				},
+			}
+
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: tc.volumeAttributes,
+						},
+					},
+				},
+			}
+
+			pod, err := creator.HeadroomPod(workloadPod, pv)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+				if tc.expectedErrorMsg != "" && !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tc.expectedErrorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, got %v", err)
+				}
+				if tc.verifyPod != nil {
+					tc.verifyPod(t, pod)
+				}
+			}
+		})
+	}
+}
+
+func TestHeadroomPodNameFor(t *testing.T) {
+	testCases := []struct {
+		name         string
+		workloadUID  string
+		pvName       string
+		expectedName string
+	}{
+		{
+			name:         "standard pod and pv",
+			workloadUID:  "pod-123",
+			pvName:       "pv-456",
+			expectedName: "hr-4a9703f375169c248f447afc10bed9459a12ded40eccd3104835ed3e",
+		},
+		{
+			name:         "empty uid",
+			workloadUID:  "",
+			pvName:       "pv-789",
+			expectedName: "hr-21739e0f8b2f3fda07bec18d48da2e8255b957504f32d311bd39cbee",
+		},
+		{
+			name:         "empty pv name",
+			workloadUID:  "pod-abc",
+			pvName:       "",
+			expectedName: "hr-e1d6cb42b532365443b43e5708daf02cc9799fad4c8d37e53e32192c",
+		},
+		{
+			name:         "both empty",
+			workloadUID:  "",
+			pvName:       "",
+			expectedName: "hr-d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
+		},
+		{
+			name:         "consistent hashing",
+			workloadUID:  "test-uid",
+			pvName:       "test-pv",
+			expectedName: "hr-aae734ade8800262147c73f5dffabd7f293cbd616b5ffd7066914a58",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			workloadPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID(tc.workloadUID),
+				},
+			}
+
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.pvName,
+				},
+			}
+
+			name := mppod.HeadroomPodNameFor(workloadPod, pv)
+			assert.Equals(t, tc.expectedName, name)
+
+			// Verify consistency - calling again should return same name
+			name2 := mppod.HeadroomPodNameFor(workloadPod, pv)
+			assert.Equals(t, name, name2)
+		})
+	}
+}
+
+func TestIsHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name       string
+		podName    string
+		isHeadroom bool
+	}{
+		{
+			name:       "valid headroom pod",
+			podName:    "hr-abc123",
+			isHeadroom: true,
+		},
+		{
+			name:       "valid headroom pod with long hash",
+			podName:    "hr-d0f23a1ff0ad96e4cf087a2aa04b54f09a456b926b87f49b9b93c72c",
+			isHeadroom: true,
+		},
+		{
+			name:       "not a headroom pod - different prefix",
+			podName:    "mp-abc123",
+			isHeadroom: false,
+		},
+		{
+			name:       "not a headroom pod - no prefix",
+			podName:    "abc123",
+			isHeadroom: false,
+		},
+		{
+			name:       "edge case - hr without dash",
+			podName:    "hrabc123",
+			isHeadroom: false,
+		},
+		{
+			name:       "edge case - just hr-",
+			podName:    "hr-",
+			isHeadroom: true,
+		},
+		{
+			name:       "empty name",
+			podName:    "",
+			isHeadroom: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.podName,
+				},
+			}
+
+			result := mppod.IsHeadroomPod(pod)
+			assert.Equals(t, tc.isHeadroom, result)
+		})
+	}
+}
+
+func TestLabelWorkloadPodForHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialLabels map[string]string
+		expectAdded   bool
+	}{
+		{
+			name:          "add label to pod without labels",
+			initialLabels: nil,
+			expectAdded:   true,
+		},
+		{
+			name:          "add label to pod with existing labels",
+			initialLabels: map[string]string{"existing": "label"},
+			expectAdded:   true,
+		},
+		{
+			name:          "label already exists",
+			initialLabels: map[string]string{mppod.LabelHeadroomForWorkload: "existing-uid"},
+			expectAdded:   false,
+		},
+		{
+			name:          "empty map",
+			initialLabels: map[string]string{},
+			expectAdded:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:    types.UID("test-uid-123"),
+					Labels: tc.initialLabels,
+				},
+			}
+
+			added := mppod.LabelWorkloadPodForHeadroomPod(pod)
+			assert.Equals(t, tc.expectAdded, added)
+
+			// Verify label is set correctly
+			if pod.Labels == nil {
+				t.Fatal("Expected pod.Labels to not be nil")
+			}
+			if tc.expectAdded {
+				assert.Equals(t, "test-uid-123", pod.Labels[mppod.LabelHeadroomForWorkload])
+			}
+
+			// Verify existing labels are preserved
+			if tc.initialLabels != nil {
+				for k, v := range tc.initialLabels {
+					if k != mppod.LabelHeadroomForWorkload || !tc.expectAdded {
+						assert.Equals(t, v, pod.Labels[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestWorkloadHasLabelPodForHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		labels   map[string]string
+		hasLabel bool
+	}{
+		{
+			name:     "has label",
+			labels:   map[string]string{mppod.LabelHeadroomForWorkload: "some-uid"},
+			hasLabel: true,
+		},
+		{
+			name:     "no label",
+			labels:   map[string]string{"other": "label"},
+			hasLabel: false,
+		},
+		{
+			name:     "empty label value",
+			labels:   map[string]string{mppod.LabelHeadroomForWorkload: ""},
+			hasLabel: false,
+		},
+		{
+			name:     "nil labels",
+			labels:   nil,
+			hasLabel: false,
+		},
+		{
+			name:     "empty map",
+			labels:   map[string]string{},
+			hasLabel: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.labels,
+				},
+			}
+
+			result := mppod.WorkloadHasLabelPodForHeadroomPod(pod)
+			assert.Equals(t, tc.hasLabel, result)
+		})
+	}
+}
+
+func TestUnlabelWorkloadPodForHeadroomPod(t *testing.T) {
+	testCases := []struct {
+		name           string
+		initialLabels  map[string]string
+		expectRemoved  bool
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "remove existing label",
+			initialLabels:  map[string]string{mppod.LabelHeadroomForWorkload: "uid-123", "other": "label"},
+			expectRemoved:  true,
+			expectedLabels: map[string]string{"other": "label"},
+		},
+		{
+			name:           "label doesn't exist",
+			initialLabels:  map[string]string{"other": "label"},
+			expectRemoved:  false,
+			expectedLabels: map[string]string{"other": "label"},
+		},
+		{
+			name:           "empty label value",
+			initialLabels:  map[string]string{mppod.LabelHeadroomForWorkload: ""},
+			expectRemoved:  false,
+			expectedLabels: map[string]string{mppod.LabelHeadroomForWorkload: ""},
+		},
+		{
+			name:          "nil labels",
+			initialLabels: nil,
+			expectRemoved: false,
+		},
+		{
+			name:           "only headroom label",
+			initialLabels:  map[string]string{mppod.LabelHeadroomForWorkload: "uid"},
+			expectRemoved:  true,
+			expectedLabels: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.initialLabels,
+				},
+			}
+
+			removed := mppod.UnlabelWorkloadPodForHeadroomPod(pod)
+			assert.Equals(t, tc.expectRemoved, removed)
+
+			// Verify expected labels
+			if tc.expectedLabels != nil {
+				if pod.Labels == nil {
+					t.Fatal("Expected pod.Labels to not be nil")
+				}
+				assert.Equals(t, len(tc.expectedLabels), len(pod.Labels))
+				for k, v := range tc.expectedLabels {
+					assert.Equals(t, v, pod.Labels[k])
+				}
+			}
+		})
+	}
+}
+
+func TestShouldReserveHeadroomForMountpointPod(t *testing.T) {
+	testCases := []struct {
+		name            string
+		schedulingGates []corev1.PodSchedulingGate
+		shouldReserve   bool
+	}{
+		{
+			name: "has headroom scheduling gate",
+			schedulingGates: []corev1.PodSchedulingGate{
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+			},
+			shouldReserve: true,
+		},
+		{
+			name: "has headroom scheduling gate among others",
+			schedulingGates: []corev1.PodSchedulingGate{
+				{Name: "other-gate"},
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+				{Name: "another-gate"},
+			},
+			shouldReserve: true,
+		},
+		{
+			name: "no headroom scheduling gate",
+			schedulingGates: []corev1.PodSchedulingGate{
+				{Name: "other-gate"},
+			},
+			shouldReserve: false,
+		},
+		{
+			name:            "no scheduling gates",
+			schedulingGates: nil,
+			shouldReserve:   false,
+		},
+		{
+			name:            "empty scheduling gates",
+			schedulingGates: []corev1.PodSchedulingGate{},
+			shouldReserve:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: tc.schedulingGates,
+				},
+			}
+
+			result := mppod.ShouldReserveHeadroomForMountpointPod(pod)
+			assert.Equals(t, tc.shouldReserve, result)
+		})
+	}
+}
+
+func TestUngateHeadroomSchedulingGateForWorkloadPod(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		initialSchedulingGates  []corev1.PodSchedulingGate
+		expectedSchedulingGates []corev1.PodSchedulingGate
+	}{
+		{
+			name: "remove headroom gate only",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{},
+		},
+		{
+			name: "remove headroom gate among others",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+				{Name: "gate2"},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: "gate2"},
+			},
+		},
+		{
+			name: "no headroom gate to remove",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: "gate2"},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gate1"},
+				{Name: "gate2"},
+			},
+		},
+		{
+			name:                    "no scheduling gates",
+			initialSchedulingGates:  nil,
+			expectedSchedulingGates: nil,
+		},
+		{
+			name: "multiple headroom gates",
+			initialSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+				{Name: "middle"},
+				{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+			},
+			expectedSchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "middle"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: tc.initialSchedulingGates,
+				},
+			}
+
+			mppod.UngateHeadroomSchedulingGateForWorkloadPod(pod)
+
+			if tc.expectedSchedulingGates == nil {
+				if pod.Spec.SchedulingGates != nil {
+					t.Errorf("Expected pod.Spec.SchedulingGates to be nil, got %v", pod.Spec.SchedulingGates)
+				}
+			} else {
+				if pod.Spec.SchedulingGates == nil {
+					t.Fatal("Expected pod.Spec.SchedulingGates to not be nil")
+				}
+				assert.Equals(t, len(tc.expectedSchedulingGates), len(pod.Spec.SchedulingGates))
+				for i, gate := range tc.expectedSchedulingGates {
+					assert.Equals(t, gate.Name, pod.Spec.SchedulingGates[i].Name)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractVolumeAttributes(t *testing.T) {
+	testCases := []struct {
+		name               string
+		pv                 *corev1.PersistentVolume
+		expectedAttributes map[string]string
+	}{
+		{
+			name: "pv with volume attributes",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: map[string]string{
+								"key1": "value1",
+								"key2": "value2",
+							},
+						},
+					},
+				},
+			},
+			expectedAttributes: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "pv without CSI spec",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{},
+			},
+			expectedAttributes: map[string]string{},
+		},
+		{
+			name: "pv with nil volume attributes",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: nil,
+						},
+					},
+				},
+			},
+			expectedAttributes: map[string]string{},
+		},
+		{
+			name: "pv with empty volume attributes",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeAttributes: map[string]string{},
+						},
+					},
+				},
+			},
+			expectedAttributes: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mppod.ExtractVolumeAttributes(tc.pv)
+			if result == nil {
+				t.Fatal("ExtractVolumeAttributes should never return nil")
+			}
+			assert.Equals(t, len(tc.expectedAttributes), len(result))
+			for k, v := range tc.expectedAttributes {
+				assert.Equals(t, v, result[k])
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is Headroom?

**Headroom** is a capacity reservation system that solves a critical scheduling problem in resource-constrained Kubernetes clusters.

#### The Problem
In the S3 CSI driver, two pods must co-locate on the same node:
- **Workload Pod** - Your application needing S3 storage  
- **Mountpoint Pod** - CSI-managed pod providing the S3 FUSE mount

In tight resource conditions, there might only be capacity for one pod, creating a chicken-and-egg problem:
- Workload pod schedules first but can't start without the mountpoint pod
- Mountpoint pod can't schedule because there's no remaining node capacity

#### The Solution
**Headroom pods** are lightweight pause containers that:
1. **Reserve exact resources** the mountpoint pod will need
2. **Schedule alongside** the workload pod using inter-pod affinity  
3. **Get preempted** by the mountpoint pod when it's ready to schedule
4. **Enable reliable co-location** in resource-constrained environments

**Example Scenario:**
```
Node capacity: 2 CPU, 4Gi RAM

Without headroom:
✅ Workload pod:   1 CPU, 2Gi → Schedules
❌ Mountpoint pod: 1 CPU, 2Gi → Can't schedule (no space)

With headroom:
✅ Workload pod:   1 CPU, 2Gi → Schedules  
✅ Headroom pod:   1 CPU, 2Gi → Reserves space
✅ Mountpoint pod: 1 CPU, 2Gi → Preempts headroom pod
```

### Why Add This?
This optimization improves reliability for S3 volume mounting in clusters with tight resource constraints, ensuring workload pods can consistently access their storage.

---

**📋 Implementation Details:** See commit message for comprehensive technical details, configuration options, and testing coverage.