### PR TITLE
S3CSI-177: Add fsgroup to mount interface

### DIFF
--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -205,7 +205,7 @@ func TestControllerOnlyAffectsMounterCreation(t *testing.T) {
 	}
 }
 
-func (n *noopMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error {
+func (n *noopMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string) error {
 	return nil
 }
 

--- a/pkg/driver/node/mounter/fake_mounter.go
+++ b/pkg/driver/node/mounter/fake_mounter.go
@@ -10,7 +10,7 @@ import (
 type FakeMounter struct{}
 
 func (m *FakeMounter) Mount(ctx context.Context, bucketName string, target string,
-	credentialCtx credentialprovider.ProvideContext, args mountpoint.Args,
+	credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string,
 ) error {
 	return nil
 }

--- a/pkg/driver/node/mounter/mocks/mock_mount.go
+++ b/pkg/driver/node/mounter/mocks/mock_mount.go
@@ -106,17 +106,17 @@ func (mr *MockMounterMockRecorder) IsMountPoint(target interface{}) *gomock.Call
 }
 
 // Mount mocks base method.
-func (m *MockMounter) Mount(ctx context.Context, bucketName, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error {
+func (m *MockMounter) Mount(ctx context.Context, bucketName, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Mount", ctx, bucketName, target, credentialCtx, args)
+	ret := m.ctrl.Call(m, "Mount", ctx, bucketName, target, credentialCtx, args, fsGroup)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Mount indicates an expected call of Mount.
-func (mr *MockMounterMockRecorder) Mount(ctx, bucketName, target, credentialCtx, args interface{}) *gomock.Call {
+func (mr *MockMounterMockRecorder) Mount(ctx, bucketName, target, credentialCtx, args, fsGroup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mount", reflect.TypeOf((*MockMounter)(nil).Mount), ctx, bucketName, target, credentialCtx, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mount", reflect.TypeOf((*MockMounter)(nil).Mount), ctx, bucketName, target, credentialCtx, args, fsGroup)
 }
 
 // Unmount mocks base method.

--- a/pkg/driver/node/mounter/mounter.go
+++ b/pkg/driver/node/mounter/mounter.go
@@ -19,7 +19,7 @@ type ServiceRunner interface {
 
 // Mounter is an interface for mount operations
 type Mounter interface {
-	Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error
+	Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string) error
 	Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error
 	IsMountPoint(target string) (bool, error)
 }

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -196,7 +196,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -245,7 +245,7 @@ func TestPodMounter(t *testing.T) {
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 				VolumeID: testCtx.volumeID,
 				PodID:    testCtx.podUID,
-			}, mountpoint.ParseArgs(nil))
+			}, mountpoint.ParseArgs(nil), "")
 			assert.NoError(t, err)
 		})
 
@@ -259,7 +259,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -303,7 +303,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -356,7 +356,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -419,7 +419,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -485,7 +485,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -532,7 +532,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -613,7 +613,7 @@ func TestPodMounter(t *testing.T) {
 							AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 							VolumeID:             testCtx.volumeID,
 							PodID:                testCtx.podUID,
-						}, args)
+						}, args, "")
 						if err != nil {
 							log.Println("Mount failed", err)
 						}
@@ -670,7 +670,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				if err != nil {
 					log.Println("Mount failed", err)
 				}
@@ -708,7 +708,7 @@ func TestPodMounter(t *testing.T) {
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
 					PodID:                testCtx.podUID,
-				}, args)
+				}, args, "")
 				mountRes <- err
 			}()
 
@@ -750,7 +750,7 @@ func TestPodMounter(t *testing.T) {
 				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 					VolumeID: testCtx.volumeID,
 					PodID:    testCtx.podUID,
-				}, mountpoint.ParseArgs(nil))
+				}, mountpoint.ParseArgs(nil), "")
 				assert.NoError(t, err)
 			}
 
@@ -774,7 +774,7 @@ func TestPodMounter(t *testing.T) {
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 				VolumeID: testCtx.volumeID,
 				PodID:    testCtx.podUID,
-			}, mountpoint.ParseArgs(nil))
+			}, mountpoint.ParseArgs(nil), "")
 			if err == nil {
 				t.Errorf("mount shouldn't succeeded if Mountpoint does not receive the mount options")
 			}
@@ -808,7 +808,7 @@ func TestPodMounter(t *testing.T) {
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 				VolumeID: testCtx.volumeID,
 				PodID:    testCtx.podUID,
-			}, mountpoint.ParseArgs(nil))
+			}, mountpoint.ParseArgs(nil), "")
 			if err == nil {
 				t.Errorf("mount shouldn't succeeded if Mountpoint fails to start")
 			}
@@ -843,7 +843,7 @@ func TestPodMounter(t *testing.T) {
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 				VolumeID: testCtx.volumeID,
 				PodID:    testCtx.podUID,
-			}, mountpoint.ParseArgs(nil))
+			}, mountpoint.ParseArgs(nil), "")
 			if err == nil {
 				t.Errorf("mount shouldn't succeeded if Mountpoint fails to start")
 			}
@@ -876,7 +876,7 @@ func TestPodMounter(t *testing.T) {
 		err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 			VolumeID: testCtx.volumeID,
 			PodID:    testCtx.podUID,
-		}, mountpoint.ParseArgs(nil))
+		}, mountpoint.ParseArgs(nil), "")
 		assert.NoError(t, err)
 
 		ok, err = testCtx.podMounter.IsMountPoint(testCtx.targetPath)
@@ -896,7 +896,7 @@ func TestPodMounter(t *testing.T) {
 		err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 			VolumeID: testCtx.volumeID,
 			PodID:    testCtx.podUID,
-		}, mountpoint.ParseArgs(nil))
+		}, mountpoint.ParseArgs(nil), "")
 		assert.NoError(t, err)
 
 		ok, err := testCtx.podMounter.IsMountPoint(testCtx.targetPath)

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -57,7 +57,7 @@ func (m *SystemdMounter) IsMountPoint(target string) (bool, error) {
 //
 // This method will create the target path if it does not exist and if there is an existing corrupt
 // mount, it will attempt an unmount before attempting the mount.
-func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error {
+func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string) error {
 	if bucketName == "" {
 		return fmt.Errorf("bucket name is empty")
 	}

--- a/pkg/driver/node/mounter/systemd_mounter_test.go
+++ b/pkg/driver/node/mounter/systemd_mounter_test.go
@@ -395,7 +395,7 @@ func TestS3MounterMount(t *testing.T) {
 				tc.before(t, env)
 			}
 
-			err := env.mounter.Mount(env.ctx, tc.bucketName, tc.targetPath, provideCtx, mountpoint.ParseArgs(tc.options))
+			err := env.mounter.Mount(env.ctx, tc.bucketName, tc.targetPath, provideCtx, mountpoint.ParseArgs(tc.options), "")
 
 			if tc.expectedErr {
 				if err == nil {

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -71,7 +71,8 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Any())
+					gomock.Any(),
+					gomock.Eq(""))
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -106,7 +107,8 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--force-path-style"})))
+					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--force-path-style"})),
+					gomock.Eq(""))
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -144,7 +146,8 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--bar", "--foo", "--read-only", "--test=123", "--force-path-style"})))
+					gomock.Eq(mountpoint.ParseArgs([]string{"--bar", "--foo", "--read-only", "--test=123", "--force-path-style"})),
+					gomock.Eq(""))
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -182,7 +185,8 @@ func TestNodePublishVolume(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--test=123", "--force-path-style"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--read-only", "--test=123", "--force-path-style"})),
+					gomock.Eq("")).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -256,7 +260,8 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660", "--force-path-style"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660", "--force-path-style"})),
+					gomock.Eq("123")).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -294,7 +299,8 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660", "--force-path-style"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--gid=123", "--allow-other", "--dir-mode=770", "--file-mode=660", "--force-path-style"})),
+					gomock.Eq("123")).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -332,7 +338,8 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-root", "--force-path-style"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-root", "--force-path-style"})),
+					gomock.Eq("")).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -370,7 +377,8 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-other", "--force-path-style"}))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs([]string{"--allow-other", "--force-path-style"})),
+					gomock.Eq("")).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -409,7 +417,8 @@ func TestNodePublishVolumeForPodMounter(t *testing.T) {
 					gomock.Eq(credentialprovider.ProvideContext{
 						VolumeID: volumeId,
 					}),
-					gomock.Eq(mountpoint.ParseArgs(mountFlags))).Return(nil)
+					gomock.Eq(mountpoint.ParseArgs(mountFlags)),
+					gomock.Eq("123")).Return(nil)
 				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -572,7 +581,7 @@ var _ mounter.Mounter = &dummyMounter{}
 
 type dummyMounter struct{}
 
-func (d *dummyMounter) Mount(ctx context.Context, bucketName string, target string, provideCtx credentialprovider.ProvideContext, args mountpoint.Args) error {
+func (d *dummyMounter) Mount(ctx context.Context, bucketName string, target string, provideCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string) error {
 	return nil
 }
 


### PR DESCRIPTION
Adds fsGroup parameter to the Mount interface to support filesystem group permissions in Kubernetes volume mounts.
All Mount  interface implementations have been updated to include the new fsGroup parameter, and all tests and mock objects have been updated accordingly.