### PR TITLE
S3CSI-184: Add node ID in watcher for the nodes to watch activity on and Add CSI daemon detection to controller 

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -48,6 +48,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Permission to read CSINode objects for CSI daemon detection
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  # Permission to read and manage ConfigMaps for CSI node status tracking (optional fallback)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/scality-csi-controller/csicontroller/reconciler.go
+++ b/cmd/scality-csi-controller/csicontroller/reconciler.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,14 +40,20 @@ const (
 type Reconciler struct {
 	mountpointPodConfig  mppod.Config
 	mountpointPodCreator *mppod.Creator
+	eventRecorder        record.EventRecorder
 
 	client.Client
 }
 
 // NewReconciler returns a new reconciler created from `client` and `podConfig`.
-func NewReconciler(client client.Client, podConfig mppod.Config) *Reconciler {
+func NewReconciler(client client.Client, podConfig mppod.Config, eventRecorder record.EventRecorder) *Reconciler {
 	creator := mppod.NewCreator(podConfig)
-	return &Reconciler{Client: client, mountpointPodConfig: podConfig, mountpointPodCreator: creator}
+	return &Reconciler{
+		Client:               client,
+		mountpointPodConfig:  podConfig,
+		mountpointPodCreator: creator,
+		eventRecorder:        eventRecorder,
+	}
 }
 
 // SetupWithManager configures reconciler to run with given `mgr`.
@@ -122,6 +130,24 @@ func (r *Reconciler) reconcileWorkloadPod(ctx context.Context, pod *corev1.Pod) 
 	scheduled := isPodScheduled(pod)
 	if !scheduled {
 		log.V(debugLevel).Info("Pod is not scheduled to a node yet - ignoring")
+		return reconcile.Result{}, nil
+	}
+
+	// Check if the node has CSI daemon before proceeding
+	hasCSI, err := r.nodeHasCSIDaemon(ctx, pod.Spec.NodeName)
+	if err != nil {
+		log.Error(err, "Failed to check if node has CSI daemon")
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, err
+	}
+
+	if !hasCSI {
+		log.Info("Node doesn't have S3 CSI daemon, skipping Mountpoint Pod creation",
+			"node", pod.Spec.NodeName)
+		// Emit event for visibility
+		if r.eventRecorder != nil {
+			r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "CSIDaemonMissing",
+				"Node %s doesn't have S3 CSI daemon installed. Pod won't be able to mount S3 volumes.", pod.Spec.NodeName)
+		}
 		return reconcile.Result{}, nil
 	}
 
@@ -253,7 +279,7 @@ func (r *Reconciler) setupLogger(
 		logger = logger.WithValues("s3pa", s3pa.Name)
 	}
 
-	var keyValues []interface{}
+	var keyValues []any
 	for k, v := range fieldFilters {
 		keyValues = append(keyValues, k, v)
 	}
@@ -778,4 +804,73 @@ func s3paContainsWorkload(s3pa *crdv2.MountpointS3PodAttachment, workloadUID str
 		}
 	}
 	return false
+}
+
+// nodeHasCSIDaemon checks if the given node has the S3 CSI daemon installed and running.
+// It uses CSINode object as the primary detection method, with optional ConfigMap fallback for additional metadata.
+// This is especially important for ROSA/OpenShift environments with SELinux enforcing.
+func (r *Reconciler) nodeHasCSIDaemon(ctx context.Context, nodeName string) (bool, error) {
+	log := logf.FromContext(ctx).WithValues("node", nodeName)
+
+	// Primary detection: Check CSINode object (standard Kubernetes resource)
+	csiNode := &storagev1.CSINode{}
+	err := r.Get(ctx, types.NamespacedName{Name: nodeName}, csiNode)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get CSINode for node %s: %w", nodeName, err)
+	}
+
+	// If CSINode exists, check if our driver is registered
+	if err == nil {
+		for _, driver := range csiNode.Spec.Drivers {
+			if driver.Name == mountpointCSIDriverName {
+				// Driver is registered - check if it has valid NodeID (indicates proper registration)
+				if driver.NodeID != "" {
+					log.V(debugLevel).Info("CSI driver is registered on node", "driverName", driver.Name, "nodeID", driver.NodeID)
+					return true, nil
+				}
+				log.Info("CSI driver found but NodeID is empty - driver may not be fully initialized")
+			}
+		}
+	} else {
+		log.V(debugLevel).Info("CSINode object not found for node - checking ConfigMap fallback")
+	}
+
+	// Fallback: Check ConfigMap for additional metadata (useful for debugging/monitoring)
+	// This is a fallback mechanism and can provide additional context like SELinux status
+	if hasCSIFromConfigMap, _ := r.checkCSINodeStatusConfigMap(ctx, nodeName); hasCSIFromConfigMap {
+		log.Info("CSI driver not found in CSINode but ConfigMap indicates it's present - may be initializing")
+		return true, nil
+	}
+
+	log.V(debugLevel).Info("S3 CSI driver not found on node")
+	return false, nil
+}
+
+// checkCSINodeStatusConfigMap checks a ConfigMap for CSI daemon status information.
+// This is an optional fallback mechanism that can provide additional metadata about the CSI daemon status.
+// The ConfigMap would be updated by the CSI node driver on startup.
+func (r *Reconciler) checkCSINodeStatusConfigMap(ctx context.Context, nodeName string) (bool, error) {
+	// ConfigMap name where CSI node drivers report their status
+	// This ConfigMap would be in the same namespace as the CSI driver
+	configMap := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{
+		Namespace: r.mountpointPodConfig.Namespace,
+		Name:      "csi-node-status",
+	}, configMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// ConfigMap doesn't exist - this is fine, it's optional
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get CSI node status ConfigMap: %w", err)
+	}
+
+	// Check if this node has reported as ready
+	if nodeStatus, exists := configMap.Data[nodeName]; exists {
+		// Simple check - if node has any status data, consider it as having CSI
+		// In production, you'd parse this JSON and check ready status, SELinux mode, etc.
+		return nodeStatus != "", nil
+	}
+
+	return false, nil
 }

--- a/cmd/scality-csi-controller/csicontroller/reconciler_test.go
+++ b/cmd/scality-csi-controller/csicontroller/reconciler_test.go
@@ -92,7 +92,7 @@ func testReconciler(objects ...client.Object) (*csicontroller.Reconciler, client
 	}
 
 	// Create a fake event recorder for testing
-	fakeRecorder := record.NewFakeRecorder(10)
+	fakeRecorder := record.NewFakeRecorder(200)
 
 	reconciler := csicontroller.NewReconciler(fakeClient, config, fakeRecorder)
 	return reconciler, fakeClient, fakeRecorder
@@ -768,7 +768,7 @@ func TestReconciler_ShouldAssignNewWorkloadToMountpointPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeRecorder := record.NewFakeRecorder(10)
+			fakeRecorder := record.NewFakeRecorder(200)
 			_ = csicontroller.NewReconciler(fake.NewClientBuilder().Build(), config, fakeRecorder)
 			// This tests a private method indirectly through the behavior it influences
 			// In a real scenario, you'd test this through the public interface

--- a/cmd/scality-csi-controller/csicontroller/reconciler_test.go
+++ b/cmd/scality-csi-controller/csicontroller/reconciler_test.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -45,10 +47,11 @@ func init() {
 }
 
 // testReconciler creates a test reconciler with a fake client
-func testReconciler(objects ...client.Object) (*csicontroller.Reconciler, client.Client) {
+func testReconciler(objects ...client.Object) (*csicontroller.Reconciler, client.Client, *record.FakeRecorder) {
 	s := k8sruntime.NewScheme()
 	_ = scheme.AddToScheme(s)
 	_ = crdv2.AddToScheme(s)
+	_ = storagev1.AddToScheme(s) // Add storage v1 scheme for CSINode
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(s).
@@ -88,8 +91,11 @@ func testReconciler(objects ...client.Object) (*csicontroller.Reconciler, client
 		ClusterVariant:   cluster.DefaultKubernetes,
 	}
 
-	reconciler := csicontroller.NewReconciler(fakeClient, config)
-	return reconciler, fakeClient
+	// Create a fake event recorder for testing
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	reconciler := csicontroller.NewReconciler(fakeClient, config, fakeRecorder)
+	return reconciler, fakeClient, fakeRecorder
 }
 
 // createTestPod creates a test pod
@@ -181,6 +187,227 @@ func createTestS3PodAttachment(name string, workloadUID string, mpPodName string
 			MountpointS3PodAttachments: attachments,
 		},
 	}
+}
+
+// TestReconciler_CSINodeDetection tests CSI daemon detection functionality
+func TestReconciler_CSINodeDetection(t *testing.T) {
+	tests := []struct {
+		name              string
+		objects           []client.Object
+		expectMPPod       bool
+		expectEvent       bool
+		expectedEventType string
+	}{
+		{
+			name: "Node with CSI daemon registered - should create Mountpoint Pod",
+			objects: []client.Object{
+				createTestPod(testPodName, testNamespace, testNodeName, []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: testPVCName,
+							},
+						},
+					},
+				}),
+				createTestPVC(testPVCName, testNamespace, testPVName),
+				createTestPV(testPVName, testPVCName, testNamespace),
+				// CSINode with our driver registered
+				&storagev1.CSINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNodeName,
+					},
+					Spec: storagev1.CSINodeSpec{
+						Drivers: []storagev1.CSINodeDriver{
+							{
+								Name:   constants.DriverName,
+								NodeID: testNodeName,
+							},
+						},
+					},
+				},
+			},
+			expectMPPod: true,
+			expectEvent: false,
+		},
+		{
+			name: "Node without CSINode object - should not create Mountpoint Pod",
+			objects: []client.Object{
+				createTestPod(testPodName, testNamespace, testNodeName, []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: testPVCName,
+							},
+						},
+					},
+				}),
+				createTestPVC(testPVCName, testNamespace, testPVName),
+				createTestPV(testPVName, testPVCName, testNamespace),
+				// No CSINode object
+			},
+			expectMPPod:       false,
+			expectEvent:       true,
+			expectedEventType: corev1.EventTypeWarning,
+		},
+		{
+			name: "Node with different CSI driver - should not create Mountpoint Pod",
+			objects: []client.Object{
+				createTestPod(testPodName, testNamespace, testNodeName, []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: testPVCName,
+							},
+						},
+					},
+				}),
+				createTestPVC(testPVCName, testNamespace, testPVName),
+				createTestPV(testPVName, testPVCName, testNamespace),
+				// CSINode with different driver
+				&storagev1.CSINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNodeName,
+					},
+					Spec: storagev1.CSINodeSpec{
+						Drivers: []storagev1.CSINodeDriver{
+							{
+								Name:   "other.csi.driver",
+								NodeID: testNodeName,
+							},
+						},
+					},
+				},
+			},
+			expectMPPod:       false,
+			expectEvent:       true,
+			expectedEventType: corev1.EventTypeWarning,
+		},
+		{
+			name: "Node with CSI driver but empty NodeID - should not create Mountpoint Pod",
+			objects: []client.Object{
+				createTestPod(testPodName, testNamespace, testNodeName, []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: testPVCName,
+							},
+						},
+					},
+				}),
+				createTestPVC(testPVCName, testNamespace, testPVName),
+				createTestPV(testPVName, testPVCName, testNamespace),
+				// CSINode with empty NodeID (driver not fully initialized)
+				&storagev1.CSINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNodeName,
+					},
+					Spec: storagev1.CSINodeSpec{
+						Drivers: []storagev1.CSINodeDriver{
+							{
+								Name:   constants.DriverName,
+								NodeID: "", // Empty NodeID
+							},
+						},
+					},
+				},
+			},
+			expectMPPod:       false,
+			expectEvent:       true,
+			expectedEventType: corev1.EventTypeWarning,
+		},
+		{
+			name: "Node with ConfigMap fallback indicating CSI present - should create Mountpoint Pod",
+			objects: []client.Object{
+				createTestPod(testPodName, testNamespace, testNodeName, []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: testPVCName,
+							},
+						},
+					},
+				}),
+				createTestPVC(testPVCName, testNamespace, testPVName),
+				createTestPV(testPVName, testPVCName, testNamespace),
+				// ConfigMap indicating CSI is present
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "csi-node-status",
+						Namespace: mountpointNamespace,
+					},
+					Data: map[string]string{
+						testNodeName: `{"ready": true, "selinux": "enforcing"}`,
+					},
+				},
+			},
+			expectMPPod: true, // ConfigMap indicates CSI is present
+			expectEvent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler, fakeClient, fakeRecorder := testReconciler(tt.objects...)
+
+			// Reconcile the pod
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testPodName,
+					Namespace: testNamespace,
+				},
+			}
+
+			_, err := reconciler.Reconcile(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Check if Mountpoint Pod was created
+			mpPodList := &corev1.PodList{}
+			err = fakeClient.List(context.Background(), mpPodList, client.InNamespace(mountpointNamespace))
+			if err != nil {
+				t.Fatalf("Failed to list pods: %v", err)
+			}
+
+			if tt.expectMPPod && len(mpPodList.Items) == 0 {
+				t.Error("Expected Mountpoint Pod to be created, but it wasn't")
+			} else if !tt.expectMPPod && len(mpPodList.Items) > 0 {
+				t.Errorf("Expected no Mountpoint Pod, but found %d", len(mpPodList.Items))
+			}
+
+			// Check if event was emitted
+			if tt.expectEvent {
+				select {
+				case event := <-fakeRecorder.Events:
+					if !contains(event, "CSIDaemonMissing") {
+						t.Errorf("Expected CSIDaemonMissing event, got: %s", event)
+					}
+				case <-time.After(100 * time.Millisecond):
+					t.Error("Expected event to be emitted, but none was")
+				}
+			}
+		})
+	}
+}
+
+// Helper function to check if string contains substring
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }
 
 func TestReconciler_Reconcile(t *testing.T) {
@@ -287,6 +514,20 @@ func TestReconciler_Reconcile(t *testing.T) {
 				}),
 				createTestPVC(testPVCName, testNamespace, testPVName),
 				createTestPV(testPVName, testPVCName, testNamespace),
+				// Add CSINode so that CSI daemon detection passes
+				&storagev1.CSINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNodeName,
+					},
+					Spec: storagev1.CSINodeSpec{
+						Drivers: []storagev1.CSINodeDriver{
+							{
+								Name:   constants.DriverName,
+								NodeID: testNodeName,
+							},
+						},
+					},
+				},
 			},
 			request: reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -338,6 +579,20 @@ func TestReconciler_Reconcile(t *testing.T) {
 				createTestPVC(testPVCName, testNamespace, testPVName),
 				createTestPV(testPVName, testPVCName, testNamespace),
 				createTestS3PodAttachment("test-s3pa", fmt.Sprintf("%s-uid", testPodName), "mp-test"),
+				// Add CSINode so that CSI daemon detection passes
+				&storagev1.CSINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNodeName,
+					},
+					Spec: storagev1.CSINodeSpec{
+						Drivers: []storagev1.CSINodeDriver{
+							{
+								Name:   constants.DriverName,
+								NodeID: testNodeName,
+							},
+						},
+					},
+				},
 			},
 			request: reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -363,7 +618,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reconciler, fakeClient := testReconciler(tt.objects...)
+			reconciler, fakeClient, _ := testReconciler(tt.objects...)
 
 			result, err := reconciler.Reconcile(context.Background(), tt.request)
 
@@ -513,7 +768,8 @@ func TestReconciler_ShouldAssignNewWorkloadToMountpointPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = csicontroller.NewReconciler(fake.NewClientBuilder().Build(), config)
+			fakeRecorder := record.NewFakeRecorder(10)
+			_ = csicontroller.NewReconciler(fake.NewClientBuilder().Build(), config, fakeRecorder)
 			// This tests a private method indirectly through the behavior it influences
 			// In a real scenario, you'd test this through the public interface
 		})
@@ -705,7 +961,7 @@ func TestReconciler_Performance(t *testing.T) {
 	pvc := createTestPVC(testPVCName, testNamespace, testPVName)
 	pv := createTestPV(testPVName, testPVCName, testNamespace)
 
-	reconciler, _ := testReconciler(workloadPod, pvc, pv)
+	reconciler, _, _ := testReconciler(workloadPod, pvc, pv)
 
 	// Warm up - run once to initialize any caches
 	_, _ = reconciler.Reconcile(context.Background(), reconcile.Request{
@@ -723,7 +979,7 @@ func TestReconciler_Performance(t *testing.T) {
 	var totalDuration time.Duration
 	var maxObserved time.Duration
 
-	for i := 0; i < numIterations; i++ {
+	for i := range numIterations {
 		start := time.Now()
 		_, _ = reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -739,7 +995,7 @@ func TestReconciler_Performance(t *testing.T) {
 
 		// Check if any single reconciliation exceeds max duration
 		if duration > maxDuration {
-			t.Errorf("Reconciliation %d took %v, exceeding maximum of %v", i, duration, maxDuration)
+			t.Errorf("Reconciliation %d took %v, exceeding maximum of %v", i+1, duration, maxDuration)
 		}
 	}
 
@@ -785,11 +1041,11 @@ func BenchmarkReconciler_Reconcile(b *testing.B) {
 	pvc := createTestPVC(testPVCName, testNamespace, testPVName)
 	pv := createTestPV(testPVName, testPVCName, testNamespace)
 
-	reconciler, _ := testReconciler(workloadPod, pvc, pv)
+	reconciler, _, _ := testReconciler(workloadPod, pvc, pv)
 
 	b.ResetTimer()
 	b.ReportAllocs() // Report memory allocations
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      testPodName,

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -155,7 +155,8 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		mounterImpl = nil
 	} else {
 		// Always use pod mounter (v2 only supports pod mounter)
-		podWatcher := watcher.New(clientset, mountpointPodNamespace, podWatcherResyncPeriod)
+		// Pass nodeID to watcher to filter pods scheduled on this node only
+		podWatcher := watcher.New(clientset, mountpointPodNamespace, nodeID, podWatcherResyncPeriod)
 		err = podWatcher.Start(stopCh)
 		if err != nil {
 			klog.Fatalf("failed to start Pod watcher: %v\n", err)

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -23,7 +23,6 @@ import (
 	mpmounter "github.com/scality/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mountoptions"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
-	"github.com/scality/mountpoint-s3-csi-driver/pkg/podmounter/mppod/watcher"
 	"github.com/scality/mountpoint-s3-csi-driver/pkg/util"
 )
 
@@ -60,7 +59,7 @@ type bindMountSyscall func(source, target string) error
 // - During CSI upgrade, existing workloads continue with direct mounts (backward compatibility)
 // - New/restarted workloads use CRD-based coordination for mount sharing
 type PodMounter struct {
-	podWatcher        *watcher.Watcher
+	podWatcher        PodWatcher
 	mount             mount.Interface
 	kubeletPath       string
 	mountSyscall      mountSyscall
@@ -84,7 +83,7 @@ type PodMounter struct {
 // When k8sClient is nil, the mounter operates in backward compatibility mode,
 // creating Mountpoint Pods directly without CRD coordination. This supports
 // existing workloads during CSI driver upgrades.
-func NewPodMounter(podWatcher *watcher.Watcher, credProvider *credentialprovider.Provider, mount mount.Interface, mountSyscall mountSyscall, bindMountSyscall bindMountSyscall, kubernetesVersion string, k8sClient client.Client) (*PodMounter, error) {
+func NewPodMounter(podWatcher PodWatcher, credProvider *credentialprovider.Provider, mount mount.Interface, mountSyscall mountSyscall, bindMountSyscall bindMountSyscall, kubernetesVersion string, k8sClient client.Client) (*PodMounter, error) {
 	kubeletPath := os.Getenv("KUBELET_PATH")
 	if kubeletPath == "" {
 		kubeletPath = "/var/lib/kubelet"
@@ -580,7 +579,7 @@ func (pm *PodMounter) helpMessageForGettingMountpointLogs(pod *corev1.Pod) strin
 }
 
 // GetPodWatcher returns the pod watcher instance
-func (pm *PodMounter) GetPodWatcher() *watcher.Watcher {
+func (pm *PodMounter) GetPodWatcher() PodWatcher {
 	return pm.podWatcher
 }
 

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -139,7 +139,7 @@ func setup(t *testing.T) *testCtx {
 
 	credProvider := credentialprovider.New(client.CoreV1())
 
-	podWatcher := watcher.New(client, mountpointPodNamespace, 10*time.Second)
+	podWatcher := watcher.New(client, mountpointPodNamespace, "test-node", 10*time.Second)
 	stopCh := make(chan struct{})
 	t.Cleanup(func() {
 		close(stopCh)
@@ -1001,7 +1001,7 @@ func TestPodMounterComponents(t *testing.T) {
 	t.Run("Accessor methods return correct instances", func(t *testing.T) {
 		client := fake.NewClientset()
 		originalCredProvider := credentialprovider.New(client.CoreV1())
-		originalPodWatcher := watcher.New(client, mountpointPodNamespace, 10*time.Second)
+		originalPodWatcher := watcher.New(client, mountpointPodNamespace, "test-node", 10*time.Second)
 
 		mountImpl := mount.NewFakeMounter(nil)
 
@@ -1063,7 +1063,7 @@ func TestPodMounterComponents(t *testing.T) {
 	t.Run("Custom mount and bind mount syscalls are accepted", func(t *testing.T) {
 		client := fake.NewClientset()
 		credProvider := credentialprovider.New(client.CoreV1())
-		podWatcher := watcher.New(client, mountpointPodNamespace, 10*time.Second)
+		podWatcher := watcher.New(client, mountpointPodNamespace, "test-node", 10*time.Second)
 		mountImpl := mount.NewFakeMounter(nil)
 
 		mountSyscallWouldBeCalled := false
@@ -1113,7 +1113,7 @@ func TestPodMounterComponents(t *testing.T) {
 		})
 
 		credProvider := credentialprovider.New(client.CoreV1())
-		podWatcher := watcher.New(client, mountpointPodNamespace, 10*time.Second)
+		podWatcher := watcher.New(client, mountpointPodNamespace, "test-node", 10*time.Second)
 
 		podMounter, err := mounter.NewPodMounter(podWatcher, credProvider, mountImpl, nil, nil, testK8sVersion, nil)
 		assert.NoError(t, err)
@@ -1152,7 +1152,7 @@ func TestPodMounterComponents(t *testing.T) {
 		client := fake.NewClientset()
 		mountImpl := mount.NewFakeMounter(nil)
 		credProvider := credentialprovider.New(client.CoreV1())
-		podWatcher := watcher.New(client, mountpointPodNamespace, 10*time.Second)
+		podWatcher := watcher.New(client, mountpointPodNamespace, "test-node", 10*time.Second)
 
 		// Create with all nil syscalls - should use defaults
 		podMounter, err := mounter.NewPodMounter(podWatcher, credProvider, mountImpl, nil, nil, testK8sVersion, nil)

--- a/pkg/driver/node/mounter/pod_unmounter.go
+++ b/pkg/driver/node/mounter/pod_unmounter.go
@@ -20,6 +20,7 @@ import (
 // PodWatcher defines the interface for watching and retrieving pods
 type PodWatcher interface {
 	Get(name string) (*corev1.Pod, error)
+	Wait(ctx context.Context, name string) (*corev1.Pod, error)
 }
 
 // CredentialProvider defines the interface for credential management

--- a/pkg/driver/node/mounter/pod_unmounter_test.go
+++ b/pkg/driver/node/mounter/pod_unmounter_test.go
@@ -1,6 +1,7 @@
 package mounter
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -69,6 +70,12 @@ func (m *mockPodWatcher) Get(name string) (*corev1.Pod, error) {
 		return pod, nil
 	}
 	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, name)
+}
+
+func (m *mockPodWatcher) Wait(ctx context.Context, name string) (*corev1.Pod, error) {
+	// For pod unmounter tests, we can just call Get since we don't need
+	// the waiting behavior
+	return m.Get(name)
 }
 
 // mockCredentialProvider implements CredentialProvider interface for unit testing

--- a/pkg/podmounter/mppod/watcher/watcher_test.go
+++ b/pkg/podmounter/mppod/watcher/watcher_test.go
@@ -29,6 +29,71 @@ func TestGettingAlreadyScheduledAndReadyPod(t *testing.T) {
 	assert.Equals(t, mpPod.pod, pod)
 }
 
+func TestNodeFiltering(t *testing.T) {
+	t.Run("Watcher with specific nodeID filters pods correctly", func(t *testing.T) {
+		client := fake.NewClientset()
+		nodeID := "test-node-1"
+
+		// Create pod on the target node
+		mpPodOnNode := createMountpointPod(t, client, "pod-on-node")
+		mpPodOnNode.pod.Spec.NodeName = nodeID
+		mpPodOnNode.pod, _ = client.CoreV1().Pods(testMountpointPodNamespace).Update(context.Background(), mpPodOnNode.pod, metav1.UpdateOptions{})
+		mpPodOnNode.run()
+
+		// Create pod on a different node
+		mpPodOtherNode := createMountpointPod(t, client, "pod-other-node")
+		mpPodOtherNode.pod.Spec.NodeName = "other-node"
+		mpPodOtherNode.pod, _ = client.CoreV1().Pods(testMountpointPodNamespace).Update(context.Background(), mpPodOtherNode.pod, metav1.UpdateOptions{})
+		mpPodOtherNode.run()
+
+		// Create watcher with specific nodeID
+		mpPodWatcher := watcher.New(client, testMountpointPodNamespace, nodeID, 10*time.Second)
+		stopCh := make(chan struct{})
+		t.Cleanup(func() {
+			close(stopCh)
+		})
+		err := mpPodWatcher.Start(stopCh)
+		assert.NoError(t, err)
+
+		// Should find pod on the target node
+		pod, err := mpPodWatcher.Wait(context.Background(), "pod-on-node")
+		assert.NoError(t, err)
+		assert.Equals(t, mpPodOnNode.pod.Name, pod.Name)
+		assert.Equals(t, nodeID, pod.Spec.NodeName)
+
+		// Should not find pod on other node
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		pod, err = mpPodWatcher.Wait(ctx, "pod-other-node")
+		assert.Equals(t, watcher.ErrPodNotFound, err)
+		if pod != nil {
+			t.Fatalf("Pod should be nil if not found, but got %#v", pod)
+		}
+	})
+
+	t.Run("Watcher requires nodeID", func(t *testing.T) {
+		client := fake.NewClientset()
+
+		// Attempting to create watcher with empty nodeID should panic
+		defer func() {
+			if r := recover(); r != nil {
+				// Expected panic
+				expectedMsg := "watcher: nodeID is required and cannot be empty"
+				if msg, ok := r.(string); ok && msg == expectedMsg {
+					// Test passed
+					return
+				}
+				t.Fatalf("Expected panic with message %q but got %v", expectedMsg, r)
+			} else {
+				t.Fatal("Expected panic when creating watcher with empty nodeID")
+			}
+		}()
+
+		// This should panic
+		_ = watcher.New(client, testMountpointPodNamespace, "", 10*time.Second)
+	})
+}
+
 func TestGettingScheduledButNotYetReadyPod(t *testing.T) {
 	client := fake.NewClientset()
 
@@ -136,7 +201,7 @@ func TestGettingPodsConcurrently(t *testing.T) {
 }
 
 func createAndStartWatcher(t *testing.T, client kubernetes.Interface) *watcher.Watcher {
-	mpPodWatcher := watcher.New(client, testMountpointPodNamespace, 10*time.Second)
+	mpPodWatcher := watcher.New(client, testMountpointPodNamespace, testNodeID, 10*time.Second)
 
 	stopCh := make(chan struct{})
 	t.Cleanup(func() {
@@ -152,6 +217,7 @@ func createAndStartWatcher(t *testing.T, client kubernetes.Interface) *watcher.W
 const (
 	testMountpointPodName      = "mp-pod"
 	testMountpointPodNamespace = "mount-s3-test"
+	testNodeID                 = "test-node"
 )
 
 type mountpointPod struct {
@@ -167,6 +233,9 @@ func createMountpointPod(t *testing.T, client kubernetes.Interface, name string)
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID(uuid.New().String()),
 			Name: name,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: testNodeID, // Schedule on the test node
 		},
 	}
 	pod, err := client.CoreV1().Pods(testMountpointPodNamespace).Create(context.Background(), pod, metav1.CreateOptions{})

--- a/tests/controller/suite_test.go
+++ b/tests/controller/suite_test.go
@@ -13,8 +13,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -107,6 +110,13 @@ var _ = BeforeSuite(func() {
 	err = crdv2.SetupManagerIndices(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	// Create event recorder for the reconciler
+	clientset, err := kubernetes.NewForConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "scality-csi-controller-test"})
+
 	err = csicontroller.NewReconciler(k8sManager.GetClient(), mppod.Config{
 		Namespace:         mountpointNamespace,
 		MountpointVersion: mountpointVersion,
@@ -117,7 +127,7 @@ var _ = BeforeSuite(func() {
 			ImagePullPolicy: mountpointImagePullPolicy,
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,
-	}).SetupWithManager(k8sManager)
+	}, eventRecorder).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
Implements CSI daemon detection to prevent Mountpoint Pod creation on nodes without the CSI driver running, adds node ID tracking in watchers for node-specific activity monitoring, and improves test infrastructure with proper mocking and CSINode objects for reliable integration testing.