### PR TITLE
S3CSI-187: Remove configuration of legacy support toggle

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/node.yaml
@@ -79,8 +79,6 @@ spec:
               value: {{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.scality.com/
             - name: MOUNTPOINT_NAMESPACE
               value: {{ .Values.mountpointPod.namespace }}
-            - name: SUPPORT_LEGACY_SYSTEMD_MOUNTS
-              value: "{{ .Values.supportLegacySystemDMounts }}"
             - name: AWS_ENDPOINT_URL
               value: {{ coalesce .Values.node.s3EndpointUrl .Values.s3.endpointUrl }}
             - name: AWS_REGION

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -126,11 +126,6 @@ controller:
     create: true
     name: s3-csi-driver-controller-sa
 
-# Legacy systemd mount support for seamless upgrades from v1.x
-# When enabled, existing systemd mounts will be preserved during upgrade
-# and only credentials will be refreshed. New mounts will use pod mounter.
-supportLegacySystemDMounts: true
-
 # Mountpoint pod configuration
 mountpointPod:
   namespace: mount-s3

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -8,8 +8,13 @@ func UsePodMounter() bool {
 
 // SupportLegacySystemdMounts returns true if the driver should support
 // existing systemd mounts during upgrade from v1.x to v2.x.
-// When enabled, existing systemd mounts will be preserved and only
-// credentials will be refreshed. New mounts will use pod mounter.
+//
+// NOTE: This is hardcoded to true for backward compatibility.
+// Disabling this is not supported and will cause upgrade failures.
+// This function and related systemd mount handling will be removed in a future version.
 func SupportLegacySystemdMounts() bool {
-	return os.Getenv("SUPPORT_LEGACY_SYSTEMD_MOUNTS") == "true"
+	// Always enabled to ensure smooth upgrades from v1.x
+	// TODO: S3C-10414 - Remove this method and all legacy systemd mount handling in a future major version
+	// We are keeping this method as it will be needed for transition, first deprecation and then removal.
+	return true
 }


### PR DESCRIPTION
Plan:
1. `v2.0` enabled legacy support by default
2. `v2.1` Later we re-troduce the code removed here with a deprecation notice
3. `v2.2` Completely remove the support for legacy systemd based mount operations