### PR TITLE
S3CSI-192: Deps update, Kustomize for CRDs, upgrade test docs, and Scality registry for headroom image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "07:00"
       timezone: "Europe/Paris"
@@ -60,7 +60,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/tests/e2e"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "07:00"
       timezone: "Europe/Paris"
@@ -98,7 +98,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "08:00"
       timezone: "Europe/Paris"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Refer to the [official documentation site](https://scality.github.io/mountpoint-
 [![Linting and Formatting](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/linting-and-formatting.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/linting-and-formatting.yaml)
 [![Code Quality Tests](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/code-quality-tests.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/code-quality-tests.yaml)
 [![E2E Integration Tests with RING S3](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/e2e-tests.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/e2e-tests.yaml)
+[![Upgrade Tests](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/upgrade-test.yaml/badge.svg)](https://github.com/scality/mountpoint-s3-csi-driver/actions/workflows/upgrade-test.yaml)

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -135,7 +135,7 @@ mountpointPod:
   # Priority class for headroom pods (typically low priority)
   headroomPriorityClassName: mount-s3-headroom
   # Image to use for headroom pods (typically a pause container)
-  headroomImage: registry.k8s.io/pause:3.10
+  headroomImage: ghcr.io/scality/mountpoint-s3-csi-driver/pause:3.10
 
 # CRD Cleanup Configuration
 # Enable automatic cleanup of MountpointS3PodAttachment CRDs and Mountpoint Pods during helm uninstall

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# This kustomization file allows users to install CRDs directly from the repository
+# Usage: kubectl apply -k github.com/scality/mountpoint-s3-csi-driver
+
+resources:
+- charts/scality-mountpoint-s3-csi-driver/crds/mountpoints3podattachments.yaml


### PR DESCRIPTION
Cross concern as PR is too small but still reviewable
- Dependabot update
- Add kustomize for easy CRD installation
- update Readme with upgrade tests
- use Scality registry for headroom image