### PR TITLE
S3CSI-223: Upgrade mount-s3 from v1.18.0 to v1.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-ARG MOUNTPOINT_VERSION=1.18.0
+ARG MOUNTPOINT_VERSION=1.21.0
 
 # Download the mountpoint tarball and produce an installable directory
 # Building on Amazon Linux 2 because it has an old libc version. libfuse from the os


### PR DESCRIPTION
## Summary
- Upgrade Mountpoint for S3 (mount-s3) from v1.18.0 to v1.21.0
- Picks up critical fixes: close-reopen race, panic-on-unlink, unified memory pool
- Also adds: concurrent directory listing, NO_PROXY support

## Changes
- `Dockerfile`: Change `ARG MOUNTPOINT_VERSION=1.18.0` to `ARG MOUNTPOINT_VERSION=1.21.0`

## Key mount-s3 Improvements (v1.18.0 → v1.21.0)
- **v1.19.0**: Unified memory pool, NO_PROXY env support
- **v1.20.0**: Concurrent directory listing, close-reopen race fix
- **v1.21.0**: Panic-on-unlink fix, performance improvements

## Test Plan
- [x] Dockerfile edit verified against upstream
- [x] **CI E2E**: Full E2E suite runs against the built container image, validating new mount-s3 binary: data persistence, file/directory permissions, cache, multi-volume, credentials, dynamic provisioning, and performance.

Issue: S3CSI-223