### PR TITLE
S3CSI-228: Add createNamespace Helm toggle and NOTES.txt

### DIFF
--- a/charts/scality-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Thank you for using Scality CSI Driver for S3 v{{ .Chart.Version }}.
+
+Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
+
+{{- if .Release.IsUpgrade }}
+
+While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.scality.com/mounted-by-csi-driver-version"`.
+{{- end }}

--- a/charts/scality-mountpoint-s3-csi-driver/templates/mount-s3-namespace.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/templates/mount-s3-namespace.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.mountpointPod.createNamespace }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -11,3 +13,4 @@ metadata:
     pod-security.kubernetes.io/warn: restricted
     # audit: Creates audit log entries for policy violations (for compliance tracking)
     pod-security.kubernetes.io/audit: restricted
+{{- end }}

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -129,6 +129,8 @@ controller:
 # Mountpoint pod configuration
 mountpointPod:
   namespace: mount-s3
+  # Set to false if you manage the namespace yourself (e.g., GitOps, pre-created namespaces)
+  createNamespace: true
   priorityClassName: mount-s3-critical
   # Priority class for pods that can preempt headroom pods
   preemptingPriorityClassName: mount-s3-preempting


### PR DESCRIPTION
## Summary
- Add `mountpointPod.createNamespace` boolean toggle for ArgoCD/GitOps compatibility
- Add `NOTES.txt` with post-install guidance and upgrade warnings about Mountpoint pod lifecycle
- Defaults to `true` (backward compatible)

## Changes
- `values.yaml`: Add `createNamespace: true` under `mountpointPod`
- `templates/mount-s3-namespace.yaml`: Wrap namespace creation in conditional
- `templates/NOTES.txt`: New Scality-branded install/upgrade notes

## Test Plan
- [x] `helm template` renders namespace by default
- [x] `helm template --set mountpointPod.createNamespace=false` omits namespace
- [x] **CI E2E**: Chart installation via `mage e2e:install` exercises default createNamespace=true path. NOTES.txt renders on every helm install.

Issue: S3CSI-228