### PR TITLE
S3CSI-213: Fix mounter pod FSGroup for workload pods with fsGroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=2.1.0
+VERSION=2.1.1
 
 # List of allowed licenses in the CSI Driver's dependencies.
 # See https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L28 for list of canonical names for licenses.

--- a/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: scality-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Scality CSI Driver for S3. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
-version: 2.1.0
+version: 2.1.1
 kubeVersion: ">=1.30.0-0"
 home: https://github.com/scality/mountpoint-s3-csi-driver
 sources:

--- a/charts/scality-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/scality-mountpoint-s3-csi-driver/values.yaml
@@ -24,7 +24,7 @@ image:
   repository: ghcr.io/scality/mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.0"
+  tag: "2.1.1"
 
 # Node plugin configuration (DaemonSet)
 node:

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,13 +35,14 @@ Container images for the Scality CSI Driver for S3 are hosted on GHCR:
 
 | Driver Version | Image URL                                                                 |
 |---------------|----------------------------------------------------------------------------|
-| 2.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:2.1.0`                           |
+| 2.1.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:2.1.1`                           |
 
 Review [release notes](release-notes.md) for overview of changes and the [releases page](https://github.com/scality/mountpoint-s3-csi-driver/releases) for complete changelog details.
 
 ??? note "Previous Images"
     | Driver Version | Image URL                                                                 |
     |---------------|----------------------------------------------------------------------------|
+    | 2.1.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:2.1.0`                           |
     | 2.0.1         | `ghcr.io/scality/mountpoint-s3-csi-driver:2.0.1`                           |
     | 2.0.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:2.0.0`                           |
     | 1.2.0         | `ghcr.io/scality/mountpoint-s3-csi-driver:1.2.0`                           |

--- a/docs/concepts-and-reference/helm-chart-configuration-reference.md
+++ b/docs/concepts-and-reference/helm-chart-configuration-reference.md
@@ -18,7 +18,7 @@ These parameters configure the overall behavior of the CSI driver components.
 |------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|-----------------------------|
 | `image.repository`                                   | The container image repository for the CSI driver.                                                                                                 | `ghcr.io/scality/mountpoint-s3-csi-driver`             | No                          |
 | `image.pullPolicy`                                   | The image pull policy.                                                                                                                             | `IfNotPresent`                                         | No                          |
-| `image.tag`                                          | The image tag for the CSI driver. Overrides the chart's `appVersion` if set.                                                                       | `2.1.0`                                                | No                          |
+| `image.tag`                                          | The image tag for the CSI driver. Overrides the chart's `appVersion` if set.                                                                       | `2.1.1`                                                | No                          |
 
 ## S3 Global Configuration
 

--- a/docs/concepts-and-reference/pod-security-and-fsgroup.md
+++ b/docs/concepts-and-reference/pod-security-and-fsgroup.md
@@ -1,0 +1,214 @@
+# Pod Security and FSGroup
+
+This page explains how Kubernetes pod security contexts — specifically `fsGroup` — interact with the Scality CSI Driver for S3 and its pod mounter architecture.
+
+## Background: Kubernetes fsGroup
+
+When a pod's `securityContext` specifies an `fsGroup`, Kubernetes changes the group ownership of all volumes mounted into that pod to match the specified GID.
+This includes CSI volumes, emptyDir volumes, and others.
+
+```yaml
+spec:
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001       # Kubernetes sets GID on all mounted volumes
+  containers:
+    - name: app
+      # ...
+```
+
+This is commonly used to ensure that non-root processes can read and write to shared volumes.
+
+## How the CSI Driver Handles fsGroup
+
+The Scality CSI Driver for S3 uses a [pod mounter architecture](../architecture/pod-mounter-architecture.md) where dedicated **Mountpoint Pods** run the mount-s3 (FUSE) process
+on behalf of workload pods. The communication between the CSI node driver and the Mountpoint Pod happens over a Unix socket inside a shared emptyDir volume.
+
+```text
+[Workload Pod]                    [Mountpoint Pod]
+  securityContext:                  securityContext:
+    fsGroup: <any>                    fsGroup: 1000  (set by CSI driver)
+        |                                 |
+        |                            /comm/mount.sock
+        |                                 |
+   NodePublishVolume ──────────> mount-s3 (FUSE process)
+        |                                 |
+   bind mount  <───────────────  S3 FUSE mount
+```
+
+The driver automatically configures the Mountpoint Pod's security context:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `PodSecurityContext.FSGroup` | `1000` | Ensures the communication emptyDir has correct group ownership |
+| `SecurityContext.RunAsUser` | `1000` | mount-s3 runs as non-root user |
+| `SecurityContext.RunAsNonRoot` | `true` | Enforces non-root execution |
+
+This is handled internally by the CSI driver — no user configuration is needed.
+
+## Using fsGroup in Workload Pods
+
+Workload pods **can freely use `fsGroup`** in their security context. The workload pod's `fsGroup` does not affect the Mountpoint Pod's internal communication.
+The CSI driver manages the Mountpoint Pod's security context independently.
+
+### Static Provisioning Example
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3-pv
+spec:
+  capacity:
+    storage: 1200Gi
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  claimRef:
+    namespace: default
+    name: s3-pvc
+  mountOptions:
+    - uid=1001
+    - gid=1001
+    - allow-other
+  csi:
+    driver: s3.csi.scality.com
+    volumeHandle: s3-csi-fsgroup-example
+    volumeAttributes:
+      bucketName: my-bucket
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1200Gi
+  volumeName: s3-pv
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: s3-app
+spec:
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001
+  containers:
+    - name: app
+      image: ubuntu
+      command: ["/bin/sh", "-c", "echo hello > /data/test.txt; tail -f /dev/null"]
+      volumeMounts:
+        - name: s3-volume
+          mountPath: /data
+  volumes:
+    - name: s3-volume
+      persistentVolumeClaim:
+        claimName: s3-pvc
+```
+
+### Dynamic Provisioning Example
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: s3-sc
+provisioner: s3.csi.scality.com
+reclaimPolicy: Delete
+mountOptions:
+  - uid=1001
+  - gid=1001
+  - allow-other
+parameters:
+  csi.storage.k8s.io/provisioner-secret-name: s3-provisioner-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-publish-secret-name: s3-node-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: default
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: s3-sc
+  resources:
+    requests:
+      storage: 1200Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: s3-app
+  template:
+    metadata:
+      labels:
+        app: s3-app
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: app
+          image: ubuntu
+          command: ["/bin/sh", "-c", "echo hello > /data/test.txt; tail -f /dev/null"]
+          volumeMounts:
+            - name: s3-volume
+              mountPath: /data
+      volumes:
+        - name: s3-volume
+          persistentVolumeClaim:
+            claimName: s3-pvc
+```
+
+## Relationship Between fsGroup and Mount Options
+
+The `fsGroup` in a pod's security context and the `uid`/`gid` mount options serve different purposes:
+
+| Setting | Scope | Purpose |
+|---------|-------|---------|
+| `uid=<ID>` (mount option) | S3 FUSE mount | Sets the UID that mount-s3 reports for all files and directories in the mounted S3 bucket |
+| `gid=<ID>` (mount option) | S3 FUSE mount | Sets the GID that mount-s3 reports for all files and directories in the mounted S3 bucket |
+| `fsGroup` (pod security context) | Kubernetes volumes | Kubernetes sets the group ownership of volume mounts inside the pod to this GID |
+| `runAsUser` (pod security context) | Container process | The UID the container process runs as |
+| `runAsGroup` (pod security context) | Container process | The primary GID of the container process |
+
+For S3 volumes, the `uid` and `gid` mount options control what ownership mount-s3 presents for S3 objects.
+The `allow-other` mount option is required so that processes running as a different UID/GID (the workload pod's `runAsUser`/`runAsGroup`) can access the mount.
+
+A common configuration pattern is to align these values:
+
+```yaml
+# Mount options on PV or StorageClass
+mountOptions:
+  - uid=1001
+  - gid=1001
+  - allow-other
+
+# Pod security context
+securityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001        # Safe to use — does not affect mounter pod
+```
+
+## Volume Sharing and fsGroup
+
+When multiple workload pods share the same S3 volume, the CSI driver considers `fsGroup` as part of the matching criteria for sharing a Mountpoint Pod.
+Pods with different `fsGroup` values will get separate Mountpoint Pods, even if they reference the same PersistentVolume.
+
+For details on volume sharing behavior, see [Pod Mounter Architecture - Volume Sharing](../architecture/pod-mounter-architecture.md#volume-sharing).

--- a/docs/concepts-and-reference/pod-security-and-fsgroup.md
+++ b/docs/concepts-and-reference/pod-security-and-fsgroup.md
@@ -190,6 +190,13 @@ The `fsGroup` in a pod's security context and the `uid`/`gid` mount options serv
 For S3 volumes, the `uid` and `gid` mount options control what ownership mount-s3 presents for S3 objects.
 The `allow-other` mount option is required so that processes running as a different UID/GID (the workload pod's `runAsUser`/`runAsGroup`) can access the mount.
 
+!!! note "fsGroup takes precedence over --gid"
+    When a workload pod specifies `fsGroup` in its security context, the CSI driver
+    **overrides** any `--gid` value set in PV or StorageClass mount options.
+    The pod-level security intent (`fsGroup`) always wins. The driver also
+    automatically sets `--allow-other`, `--dir-mode=770`, and `--file-mode=660` if
+    not already present. The `--uid` mount option is not affected.
+
 A common configuration pattern is to align these values:
 
 ```yaml

--- a/docs/driver-deployment/installation-guide.md
+++ b/docs/driver-deployment/installation-guide.md
@@ -118,7 +118,7 @@ Deploy the driver with minimal configuration.
 ```bash
 helm install scality-mountpoint-s3-csi-driver \
   oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version 2.1.0 \
+  --version 2.1.1 \
   --set node.s3EndpointUrl="${S3_ENDPOINT_URL}" \
   --set s3CredentialSecret.name="${SECRET_NAME}" \
   --namespace ${NAMESPACE}
@@ -192,7 +192,7 @@ Deploy the driver using the custom values file.
 ```bash
 helm install scality-mountpoint-s3-csi-driver \
   oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version 2.1.0 \
+  --version 2.1.1 \
   --values values-production.yaml \
   --namespace ${NAMESPACE}
 ```

--- a/docs/driver-deployment/prerequisites.md
+++ b/docs/driver-deployment/prerequisites.md
@@ -25,7 +25,7 @@ The deployment of the Scality CSI Driver for S3 requires access to several conta
 
 | Component | Image | Registry | Purpose |
 |-----------|-------|----------|---------|
-| **Scality CSI Driver for S3** | `ghcr.io/scality/mountpoint-s3-csi-driver:2.1.0` | GitHub Container Registry (GHCR) | Main CSI driver functionality |
+| **Scality CSI Driver for S3** | `ghcr.io/scality/mountpoint-s3-csi-driver:2.1.1` | GitHub Container Registry (GHCR) | Main CSI driver functionality |
 | **CSI Node Driver Registrar** | `ghcr.io/scality/mountpoint-s3-csi-driver/csi-node-driver-registrar:v2.14.0` | GitHub Container Registry (GHCR) | Registers CSI driver with kubelet |
 | **Liveness Probe** | `ghcr.io/scality/mountpoint-s3-csi-driver/livenessprobe:v2.16.0` | GitHub Container Registry (GHCR) | Health monitoring for CSI driver pods |
 | **CSI Provisioner** | `ghcr.io/scality/mountpoint-s3-csi-driver/csi-provisioner:v5.3.0` | GitHub Container Registry (GHCR) | External provisioner for CSI driver (Dynamic provisioning feature) |

--- a/docs/driver-deployment/quick-start.md
+++ b/docs/driver-deployment/quick-start.md
@@ -47,7 +47,7 @@ kubectl create secret generic s3-secret \
 helm install \
   scality-mountpoint-s3-csi-driver \
   oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version 2.1.0 \
+  --version 2.1.1 \
   --set node.s3EndpointUrl="${S3_ENDPOINT_URL}"
 ```
 

--- a/docs/driver-deployment/upgrade-guide.md
+++ b/docs/driver-deployment/upgrade-guide.md
@@ -94,7 +94,7 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=scality-mountpoint-s3
 # Test upgrade to v2.0 without applying changes
 helm upgrade scality-mountpoint-s3-csi-driver \
   oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version 2.1.0 \
+  --version 2.1.1 \
   --namespace ${NAMESPACE} \
   --reuse-values \
   --dry-run
@@ -118,7 +118,7 @@ For installations using existing configuration:
 ```bash
 helm upgrade scality-mountpoint-s3-csi-driver \
   oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version 2.1.0 \
+  --version 2.1.1 \
   --namespace ${NAMESPACE} \
   --reuse-values
 ```
@@ -130,7 +130,7 @@ For installations with custom configuration file:
 ```bash
 helm upgrade scality-mountpoint-s3-csi-driver \
   oci://ghcr.io/scality/mountpoint-s3-csi-driver/helm-charts/scality-mountpoint-s3-csi-driver \
-  --version 2.1.0 \
+  --version 2.1.1 \
   --values values-production.yaml \
   --namespace ${NAMESPACE}
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,12 @@ February 2026
   `PodSecurityContext`, ensuring the communication directory is writable by the non-root mount-s3
   process regardless of the workload pod's `fsGroup` configuration.
 
+### Documentation
+
+- **Pod Security and FSGroup**: Added [Pod Security and FSGroup](concepts-and-reference/pod-security-and-fsgroup.md)
+  reference page explaining how Kubernetes `fsGroup` interacts with the CSI driver's pod mounter,
+  including configuration examples for static and dynamic provisioning.
+
 ### Breaking Changes
 
 None.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## [2.1.1](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/2.1.1)
+
+February 2026
+
+### Bug Fixes
+
+- **Mounter Pod FSGroup**: Fixed volume mount failure when workload pods specify `fsGroup` in their
+  `securityContext`. The mounter pod's communication socket (`/comm/mount.sock`) timed out because
+  the emptyDir volume lacked proper group ownership. The fix adds `FSGroup` to the mounter pod's
+  `PodSecurityContext`, ensuring the communication directory is writable by the non-root mount-s3
+  process regardless of the workload pod's `fsGroup` configuration.
+
+### Breaking Changes
+
+None.
+
 ## [2.1.0](https://github.com/scality/mountpoint-s3-csi-driver/releases/tag/2.1.0)
 
 January 27, 2026

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
           - StorageClass Reference and Usage Examples: volume-provisioning/dynamic-provisioning/storageclass-reference-and-usage-examples.md
   - Concepts and Reference:
       - Helm Chart Configuration Reference: concepts-and-reference/helm-chart-configuration-reference.md
+      - Pod Security and FSGroup: concepts-and-reference/pod-security-and-fsgroup.md
       - CRD Reference: architecture/crd-reference.md
       - Filesystem Semantics: concepts-and-reference/filesystem-semantics.md
   - Operations:

--- a/pkg/driver/node/credentialprovider/provider.go
+++ b/pkg/driver/node/credentialprovider/provider.go
@@ -68,6 +68,7 @@ type ProvideContext struct {
 	EnvPath string
 
 	PodID    string
+	PodName  string
 	VolumeID string
 
 	// The following values are provided from CSI volume context.

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -272,6 +272,7 @@ func credentialProvideContextFromPublishRequest(req *csi.NodePublishVolumeReques
 
 	return credentialprovider.ProvideContext{
 		PodID:                podID,
+		PodName:              volumeCtx[volumecontext.CSIPodName],
 		VolumeID:             req.GetVolumeId(),
 		AuthenticationSource: volumeCtx[volumecontext.AuthenticationSource],
 		PodNamespace:         volumeCtx[volumecontext.CSIPodNamespace],

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -15,6 +15,7 @@ const (
 
 	CSIServiceAccountName   = "csi.storage.k8s.io/serviceAccount.name"
 	CSIServiceAccountTokens = "csi.storage.k8s.io/serviceAccount.tokens"
+	CSIPodName              = "csi.storage.k8s.io/pod.name"
 	CSIPodNamespace         = "csi.storage.k8s.io/pod.namespace"
 	CSIPodUID               = "csi.storage.k8s.io/pod.uid"
 )

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -79,6 +79,9 @@ func (c *Creator) Create(pod *corev1.Pod, pv *corev1.PersistentVolume) *corev1.P
 			// here `restartPolicy: OnFailure` allows Pod to only restart on non-zero exit codes (i.e. some failures)
 			// and not successful exists (i.e. zero exit code).
 			RestartPolicy: corev1.RestartPolicyOnFailure,
+			SecurityContext: &corev1.PodSecurityContext{
+				FSGroup: c.config.ClusterVariant.MountpointPodUserID(),
+			},
 			Containers: []corev1.Container{{
 				Name:            "mountpoint",
 				Image:           c.config.Container.Image,

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -172,7 +172,7 @@ func TestNewCreator(t *testing.T) {
 			Image:           "test-image:latest",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 		},
-		CSIDriverVersion: "2.1.0",
+		CSIDriverVersion: "2.1.1",
 		ClusterVariant:   cluster.DefaultKubernetes,
 	}
 

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -58,6 +58,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 
 		assert.Equals(t, priorityClassName, mpPod.Spec.PriorityClassName)
 		assert.Equals(t, corev1.RestartPolicyOnFailure, mpPod.Spec.RestartPolicy)
+		assert.Equals(t, expectedRunAsUser, mpPod.Spec.SecurityContext.FSGroup)
 		assert.Equals(t, []corev1.Volume{
 			{
 				Name: mppod.CommunicationDirName,
@@ -203,6 +204,7 @@ func TestNewCreator(t *testing.T) {
 	assert.Equals(t, config.MountpointVersion, mpPod.Labels[mppod.LabelMountpointVersion])
 	assert.Equals(t, config.CSIDriverVersion, mpPod.Labels[mppod.LabelCSIDriverVersion])
 	assert.Equals(t, config.PriorityClassName, mpPod.Spec.PriorityClassName)
+	assert.Equals(t, config.ClusterVariant.MountpointPodUserID(), mpPod.Spec.SecurityContext.FSGroup)
 	assert.Equals(t, config.Container.Image, mpPod.Spec.Containers[0].Image)
 	assert.Equals(t, config.Container.ImagePullPolicy, mpPod.Spec.Containers[0].ImagePullPolicy)
 	assert.Equals(t, []string{config.Container.Command}, mpPod.Spec.Containers[0].Command)

--- a/tests/e2e/customsuites/mounterpod.go
+++ b/tests/e2e/customsuites/mounterpod.go
@@ -1,0 +1,259 @@
+/*
+This suite tests the mounter pod infrastructure — the dedicated Kubernetes pods
+that run mount-s3 (FUSE) on behalf of workload pods.
+
+Covered behaviors:
+
+  - FSGroup: Ensures the mounter pod's PodSecurityContext.FSGroup is set to the
+    default MountpointPodUserID (1000), so shared volumes like the emptyDir
+    communication directory have correct group ownership.
+  - RunAsUser: Verifies the mounter container runs as the expected non-root UID.
+  - RunAsNonRoot: Confirms privilege restrictions on the mounter container.
+  - Workload FSGroup compatibility: Verifies that workload pods with fsGroup set
+    in their PodSecurityContext can successfully mount S3 volumes and read/write
+    data. This reproduces the customer-reported issue where fsGroup on the
+    workload pod caused the mounter pod's communication socket to time out.
+
+These tests validate that the CSI driver spawns properly secured mounter pods.
+*/
+package customsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
+
+	"github.com/scality/mountpoint-s3-csi-driver/tests/e2e/constants"
+)
+
+const (
+	// mounterPodNamespace is the namespace where mounter pods are created.
+	// Must match the Helm chart value for mountpointPod.namespace.
+	mounterPodNamespace = "mount-s3"
+
+	// Label key used on mounter pods (mirrors pkg/podmounter/mppod/creator.go LabelVolumeName).
+	labelVolumeName = constants.DriverName + "/volume-name"
+
+	// expectedFSGroup is the default MountpointPodUserID for vanilla Kubernetes.
+	expectedFSGroup = int64(1000)
+)
+
+type s3CSIMounterPodTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+// InitS3MounterPodTestSuite returns a test suite for mounter pod infrastructure.
+//
+// This suite tests:
+// - Mounter pod FSGroup is set correctly in PodSecurityContext
+// - Mounter container runs as the expected non-root user
+func InitS3MounterPodTestSuite() storageframework.TestSuite {
+	return &s3CSIMounterPodTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "mounterpod",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (suite *s3CSIMounterPodTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return suite.tsInfo
+}
+
+func (suite *s3CSIMounterPodTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (suite *s3CSIMounterPodTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type TestResourceRegistry struct {
+		resources []*storageframework.VolumeResource
+		config    *storageframework.PerTestConfig
+	}
+	var testRegistry TestResourceRegistry
+
+	testFramework := framework.NewFrameworkWithCustomTimeouts("mounterpod", storageframework.GetDriverTimeouts(driver))
+	testFramework.NamespacePodSecurityLevel = admissionapi.LevelRestricted
+
+	cleanup := func() {
+		for i := range testRegistry.resources {
+			resource := testRegistry.resources[i]
+			func() {
+				defer ginkgo.GinkgoRecover()
+				ctx := context.Background()
+				ginkgo.By("Deleting pv and pvc")
+				err := resource.CleanupResource(ctx)
+				if err != nil {
+					framework.Logf("Warning: Resource cleanup had an error: %v", err)
+				}
+			}()
+		}
+	}
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		testRegistry = TestResourceRegistry{}
+		testRegistry.config = driver.PrepareTest(ctx, testFramework)
+		ginkgo.DeferCleanup(cleanup)
+	})
+
+	// --------------------------------------------------------------------
+	// 1. Mounter pod FSGroup
+	//
+	// When the CSI driver creates a mounter pod to run mount-s3 as a FUSE
+	// process, the pod must have FSGroup set in its PodSecurityContext.
+	// This ensures that shared volumes (e.g., the emptyDir communication
+	// directory between the CSI node driver and the mounter process) have
+	// proper group ownership, allowing the non-root mount-s3 process to
+	// read/write them.
+	//
+	// Diagram:
+	//
+	//      [Workload Pod]
+	//            |
+	//      NodePublishVolume
+	//            |
+	//            ↓
+	//      [Mounter Pod]  ←── spec.securityContext.fsGroup = 1000
+	//            |
+	//         mount-s3
+	//            |
+	//            ↓
+	//      [S3 FUSE Mount]
+	//
+	// Expected results:
+	// - The mounter pod in the mount-s3 namespace has PodSecurityContext.FSGroup = 1000
+	// - The mounter container has SecurityContext.RunAsUser = 1000
+	// - The mounter container has SecurityContext.RunAsNonRoot = true
+	ginkgo.It("should set FSGroup on the mounter pod security context", func(ctx context.Context) {
+		ginkgo.By("Creating a volume with standard mount options")
+		res := BuildVolumeWithOptions(ctx, testRegistry.config, pattern,
+			DefaultNonRootUser, DefaultNonRootGroup, "0644")
+		testRegistry.resources = append(testRegistry.resources, res)
+
+		pvName := res.Pv.Name
+
+		ginkgo.By("Creating a workload pod that mounts the volume")
+		pod, err := CreatePodWithVolumeAndSecurity(ctx, testFramework, res.Pvc, "",
+			DefaultNonRootUser, DefaultNonRootGroup)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer e2epod.DeletePodWithWait(ctx, testFramework.ClientSet, pod)
+
+		ginkgo.By(fmt.Sprintf("Finding the mounter pod for volume %s in namespace %s", pvName, mounterPodNamespace))
+		var mounterPodFSGroup *int64
+		var mounterPodRunAsUser *int64
+		var mounterPodRunAsNonRoot *bool
+		gomega.Eventually(func(g gomega.Gomega) {
+			pods, err := testFramework.ClientSet.CoreV1().Pods(mounterPodNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", labelVolumeName, pvName),
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(pods.Items).NotTo(gomega.BeEmpty(), "no mounter pod found for volume %s", pvName)
+
+			mounterPod := pods.Items[0]
+			g.Expect(mounterPod.Spec.SecurityContext).NotTo(gomega.BeNil(),
+				"mounter pod should have PodSecurityContext")
+			g.Expect(mounterPod.Spec.SecurityContext.FSGroup).NotTo(gomega.BeNil(),
+				"mounter pod should have FSGroup set in PodSecurityContext")
+			mounterPodFSGroup = mounterPod.Spec.SecurityContext.FSGroup
+
+			g.Expect(mounterPod.Spec.Containers).NotTo(gomega.BeEmpty())
+			g.Expect(mounterPod.Spec.Containers[0].SecurityContext).NotTo(gomega.BeNil())
+			mounterPodRunAsUser = mounterPod.Spec.Containers[0].SecurityContext.RunAsUser
+			mounterPodRunAsNonRoot = mounterPod.Spec.Containers[0].SecurityContext.RunAsNonRoot
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying the mounter pod FSGroup matches the expected MountpointPodUserID")
+		gomega.Expect(*mounterPodFSGroup).To(gomega.Equal(expectedFSGroup),
+			"mounter pod FSGroup should be %d (default MountpointPodUserID)", expectedFSGroup)
+
+		ginkgo.By("Verifying the mounter container runs as the expected non-root user")
+		gomega.Expect(mounterPodRunAsUser).NotTo(gomega.BeNil())
+		gomega.Expect(*mounterPodRunAsUser).To(gomega.Equal(expectedFSGroup),
+			"mounter pod RunAsUser should be %d", expectedFSGroup)
+
+		ginkgo.By("Verifying the mounter container enforces RunAsNonRoot")
+		gomega.Expect(mounterPodRunAsNonRoot).NotTo(gomega.BeNil())
+		gomega.Expect(*mounterPodRunAsNonRoot).To(gomega.BeTrue(),
+			"mounter pod RunAsNonRoot should be true")
+	})
+
+	// --------------------------------------------------------------------
+	// 2. Workload pod with fsGroup can mount and use S3 volumes
+	//
+	// Reproduces the customer-reported issue where workload pods with
+	// fsGroup in their PodSecurityContext failed to mount S3 volumes.
+	// The mounter pod's communication socket (/comm/mount.sock)
+	// timed out because the emptyDir volume had incorrect group ownership.
+	//
+	// The fix (adding FSGroup to the mounter pod's PodSecurityContext)
+	// ensures the communication directory is writable regardless of
+	// what fsGroup the workload pod uses.
+	//
+	// Customer scenario:
+	//   securityContext:
+	//     fsGroup: 1001
+	//     runAsGroup: 1001
+	//     runAsUser: 1001
+	//
+	// Diagram:
+	//
+	//      [Workload Pod]
+	//        fsGroup: 1001      ← customer sets this
+	//            |
+	//      NodePublishVolume
+	//            |
+	//            ↓
+	//      [Mounter Pod]
+	//        fsGroup: 1000      ← CSI driver sets this (the fix)
+	//            |
+	//         mount-s3
+	//            |
+	//            ↓
+	//      [S3 FUSE Mount]      ← workload reads/writes here
+	//
+	// Expected results:
+	// - The workload pod reaches Running state (mount succeeds)
+	// - Data can be written and read back through the mounted volume
+	ginkgo.It("should mount volume when workload pod has fsGroup set", func(ctx context.Context) {
+		ginkgo.By("Creating a volume with standard mount options")
+		res := BuildVolumeWithOptions(ctx, testRegistry.config, pattern,
+			DefaultNonRootUser, DefaultNonRootGroup, "0644")
+		testRegistry.resources = append(testRegistry.resources, res)
+
+		ginkgo.By("Creating a workload pod with fsGroup in its PodSecurityContext")
+		pod := e2epod.MakePod(testFramework.Namespace.Name, nil,
+			[]*v1.PersistentVolumeClaim{res.Pvc}, admissionapi.LevelRestricted, "")
+		pod.Name = fmt.Sprintf("fsgroup-pod-%s", uuid.New().String()[:8])
+		podModifierNonRoot(pod)
+		// Set fsGroup on the workload pod — this is the customer's configuration
+		// that triggered the original bug.
+		pod.Spec.SecurityContext.FSGroup = ptr.To(DefaultNonRootUser)
+
+		pod, err := createPod(ctx, testFramework.ClientSet, testFramework.Namespace.Name, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"workload pod with fsGroup should reach Running state — mount must not time out")
+		defer e2epod.DeletePodWithWait(ctx, testFramework.ClientSet, pod)
+
+		ginkgo.By("Writing a file through the mounted volume")
+		volPath := "/mnt/volume1"
+		testFile := fmt.Sprintf("%s/fsgroup-test-%s.txt", volPath, uuid.New().String()[:8])
+		testContent := "fsgroup-write-test"
+		CreateFileInPod(testFramework, pod, testFile, testContent)
+
+		ginkgo.By("Reading the file back to verify the mount is fully functional")
+		e2evolume.VerifyExecInPodSucceed(testFramework, pod,
+			fmt.Sprintf("cat %s | grep -q %q", testFile, testContent))
+	})
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -11,6 +11,7 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	f "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
@@ -48,6 +49,7 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
+	format.MaxLength = 0 // Disable truncation so Gomega prints full error details
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Scality CSI Driver for S3 E2E Suite")
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -108,6 +108,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	customsuites.InitS3AdvancedPatternsTestSuite,
 	customsuites.InitS3DynamicProvisioningMountOptionsTestSuite,
 	customsuites.InitS3DynamicProvisioningTemplatingTestSuite,
+	customsuites.InitS3MounterPodTestSuite,
 }
 
 // CSI test suite registration and execution.


### PR DESCRIPTION
## Summary

- Fix volume mount failure when workload pods specify `fsGroup` in their `securityContext`. The mounter pod's communication socket (`/comm/mount.sock`) timed out because the emptyDir volume lacked proper group ownership. The fix adds `FSGroup` to the mounter pod's `PodSecurityContext`.
- Add E2E tests verifying mounter pod security context and the customer-reported fsGroup scenario.
- Bump version to v2.1.1 with release notes and documentation updates.

## Test plan

- [x] Unit tests pass (`make unit-test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests compile (`go build ./...` in `tests/e2e/`)
- [x] E2E test: mounter pod FSGroup is set correctly in PodSecurityContext
- [x] E2E test: workload pod with fsGroup can mount and write/read data
- [x] Verify Helm chart installs with updated version references